### PR TITLE
Update OpenMRS and related module versions

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -25,12 +25,12 @@
 
     <!-- track module versions
          we do so here so that we can utilise Maven to track updates, etc. -->
-    <openmrs.version>2.8.4</openmrs.version>
+    <openmrs.version>2.8.6</openmrs.version>
     <initializer.version>2.11.0</initializer.version>
     <fhir2.version>3.0.0</fhir2.version>
-    <webservices.rest.version>3.1.0</webservices.rest.version>
+    <webservices.rest.version>3.3.0</webservices.rest.version>
     <addresshierarchy.version>2.21.0</addresshierarchy.version>
-    <patientdocuments.version>1.0.0</patientdocuments.version>
+    <patientdocuments.version>1.1.0-SNAPSHOT</patientdocuments.version>
     <idgen.version>5.0.4</idgen.version>
     <legacyui.version>2.0.0</legacyui.version>
     <metadatamapping.version>2.0.0</metadatamapping.version>
@@ -56,7 +56,7 @@
     <bedmanagement.version>7.2.0</bedmanagement.version>
     <!-- Stock Management and Billing -->
     <stockmanagement.version>3.0.0</stockmanagement.version>
-    <billing.version>1.3.2</billing.version>
+    <billing.version>2.2.0</billing.version>
     <fua.version>1.0.47</fua.version>
     <!-- <sihsalus-interop.version>1.0.3</sihsalus-interop.version> -->
 


### PR DESCRIPTION
This pull request updates several module dependencies in the `backend/pom.xml` to newer versions, improving compatibility, stability, and potentially adding new features. The most significant updates include core platform and module version bumps.

**Dependency version updates:**

* Upgraded `openmrs.version` from `2.8.4` to `2.8.6`, ensuring the backend uses a more recent and stable version of the OpenMRS platform.
* Updated `webservices.rest.version` from `3.1.0` to `3.3.0`, which may bring API improvements and bug fixes.
* Changed `patientdocuments.version` from `1.0.0` to `1.1.0-SNAPSHOT`, likely enabling access to new or in-development features in the patient documents module.
* Upgraded `billing.version` from `1.3.2` to `2.2.0`, which could introduce new billing features or enhancements.