### PR TITLE
feat(monitoring): node-exporter y cAdvisor para métricas de host/contenedores

### DIFF
--- a/compose/monitoring.yml
+++ b/compose/monitoring.yml
@@ -81,6 +81,37 @@ services:
       - monitoring-network
       - default
 
+  node-exporter:
+    container_name: sihsalus-node-exporter
+    image: prom/node-exporter:v1.9.1
+    restart: "unless-stopped"
+    profiles: [ monitoring ]
+    command:
+      - '--path.rootfs=/host'
+      - '--collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)'
+      - '--collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$$'
+    volumes:
+      - /:/host:ro,rslave
+    networks:
+      - monitoring-network
+
+  cadvisor:
+    container_name: sihsalus-cadvisor
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
+    restart: "unless-stopped"
+    profiles: [ monitoring ]
+    privileged: true
+    devices:
+      - /dev/kmsg:/dev/kmsg
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+      - /dev/disk:/dev/disk:ro
+    networks:
+      - monitoring-network
+
   blackbox:
     container_name: sihsalus-blackbox
     image: prom/blackbox-exporter:v0.27.0

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,6 +1,6 @@
 # Monitoring - Observabilidad (Grafana, Prometheus, Loki, Alloy)
 
-Stack de observabilidad para disponibilidad HTTP, métricas del propio stack y logs de contenedores. No incluye métricas de CPU/memoria por contenedor hasta agregar cAdvisor/node-exporter.
+Stack de observabilidad para disponibilidad HTTP, métricas del propio stack, recursos del host, métricas de contenedores y logs de contenedores.
 
 ## Stack
 
@@ -9,6 +9,8 @@ Stack de observabilidad para disponibilidad HTTP, métricas del propio stack y l
 - **Loki** - Agregador de logs (búsqueda rápida)
 - **Alloy** - Colector opcional de logs Docker
 - **Blackbox Exporter** - Probes de disponibilidad (health checks)
+- **Node Exporter** - Métricas del host: CPU, memoria, disco, carga
+- **cAdvisor** - Métricas de contenedores Docker: CPU, memoria, red, filesystem
 
 ---
 
@@ -82,6 +84,8 @@ GRAFANA_ROOT_URL=http://localhost:3001   # URL base (para links)
 - Prometheus itself
 - Grafana
 - Loki
+- Node Exporter (host)
+- cAdvisor (contenedores Docker)
 - Blackbox HTTP probes (Gateway, OpenMRS endpoints)
 
 **Retención**: 30 días (configurable)
@@ -159,6 +163,28 @@ sum(rate({job="docker", level="error"}[5m]))
 
 ---
 
+### Node Exporter
+
+**Rol**: Métricas del host donde corre Docker: CPU, memoria, disco, carga y filesystems.
+
+**Notas**:
+- Se ejecuta dentro del profile `monitoring`.
+- Monta el root filesystem del host en modo solo lectura.
+- Las métricas principales son `node_cpu_seconds_total`, `node_memory_*` y `node_filesystem_*`.
+
+---
+
+### cAdvisor
+
+**Rol**: Métricas por contenedor Docker: CPU, memoria, red, filesystem y presencia del contenedor.
+
+**Notas**:
+- Se ejecuta dentro del profile `monitoring`.
+- Requiere acceso solo lectura a rutas del runtime Docker y `/dev/kmsg`.
+- En Docker Desktop algunas métricas pueden variar frente a Linux nativo; en producción Linux entrega la cobertura completa.
+
+---
+
 ## Dashboards
 
 ### Docker Overview
@@ -225,6 +251,18 @@ probe_duration_seconds{job="blackbox-http-prod"}
 
 # Estado de targets scrapeados
 up
+
+# Uso de CPU del host
+1 - avg(rate(node_cpu_seconds_total{job="node-exporter", mode="idle"}[5m]))
+
+# Memoria disponible del host
+node_memory_MemAvailable_bytes{job="node-exporter"}
+
+# CPU por contenedor SIHSALUS
+sum by (name) (rate(container_cpu_usage_seconds_total{job="cadvisor", name=~"sihsalus-.+", image!=""}[5m]))
+
+# Memoria por contenedor SIHSALUS
+container_memory_working_set_bytes{job="cadvisor", name=~"sihsalus-.+", image!=""}
 ```
 
 ### LogQL (Loki)

--- a/monitoring/prometheus/alerts/basic-alerts.yml
+++ b/monitoring/prometheus/alerts/basic-alerts.yml
@@ -28,3 +28,76 @@ groups:
         annotations:
           summary: "SIHSALUS endpoint is slow: {{ $labels.instance }}"
           description: "Blackbox probe duration for {{ $labels.instance }} has been above 2 seconds for more than 5 minutes."
+
+      - alert: SihsalusHostDiskSpaceLow
+        expr: |
+          (
+            node_filesystem_avail_bytes{job="node-exporter", fstype!~"tmpfs|overlay"} /
+            node_filesystem_size_bytes{job="node-exporter", fstype!~"tmpfs|overlay"}
+          ) < 0.15
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Low disk space on {{ $labels.mountpoint }}"
+          description: "Filesystem {{ $labels.device }} mounted at {{ $labels.mountpoint }} has less than 15% free space for more than 10 minutes."
+
+      - alert: SihsalusHostMemoryHigh
+        expr: |
+          1 - (
+            node_memory_MemAvailable_bytes{job="node-exporter"} /
+            node_memory_MemTotal_bytes{job="node-exporter"}
+          ) > 0.90
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High host memory usage"
+          description: "Host memory usage has been above 90% for more than 10 minutes."
+
+      - alert: SihsalusHostCpuHigh
+        expr: |
+          1 - avg by (instance) (
+            rate(node_cpu_seconds_total{job="node-exporter", mode="idle"}[5m])
+          ) > 0.90
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High host CPU usage"
+          description: "Host CPU usage has been above 90% for more than 15 minutes."
+
+      - alert: SihsalusContainerDown
+        expr: |
+          time() - container_last_seen{job="cadvisor", name=~"sihsalus-.+"} > 60
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Container {{ $labels.name }} is not reporting metrics"
+          description: "cAdvisor has not seen {{ $labels.name }} for more than 2 minutes."
+
+      - alert: SihsalusContainerMemoryHigh
+        expr: |
+          (
+            container_memory_working_set_bytes{job="cadvisor", name=~"sihsalus-.+", image!=""} /
+            (container_spec_memory_limit_bytes{job="cadvisor", name=~"sihsalus-.+", image!=""} > 0)
+          ) > 0.90
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High container memory usage: {{ $labels.name }}"
+          description: "Container {{ $labels.name }} has used more than 90% of its configured memory limit for more than 10 minutes."
+
+      - alert: SihsalusContainerCpuHigh
+        expr: |
+          sum by (name) (
+            rate(container_cpu_usage_seconds_total{job="cadvisor", name=~"sihsalus-.+", image!=""}[5m])
+          ) > 1
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High container CPU usage: {{ $labels.name }}"
+          description: "Container {{ $labels.name }} has consumed more than one CPU core for more than 15 minutes."

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -50,6 +50,20 @@ scrape_configs:
         labels:
           service: 'loki'
 
+  # Host metrics: CPU, memory, filesystem, load
+  - job_name: 'node-exporter'
+    static_configs:
+      - targets: ['node-exporter:9100']
+        labels:
+          service: 'node-exporter'
+
+  # Docker container metrics: CPU, memory, restarts, network, filesystem
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: ['cadvisor:8080']
+        labels:
+          service: 'cadvisor'
+
   # OpenMRS Backend metrics (JMX exporter - requires configuration)
   # - job_name: 'openmrs-backend'
   #   metrics_path: '/openmrs/metrics'


### PR DESCRIPTION
## Resumen
- Agrega **node-exporter** (métricas del host: CPU, memoria, disco, carga) y **cAdvisor** (métricas por contenedor Docker) al profile `monitoring`.
- Cablea ambos en el scrape config de Prometheus (`node-exporter:9100`, `cadvisor:8080`).
- Añade 6 alertas de recursos: disco bajo, memoria/CPU de host altas, contenedor caído, y memoria/CPU por contenedor.
- Actualiza `monitoring/README.md` con roles, notas y queries PromQL de ejemplo.

## Seguridad
- **node-exporter**: rootfs montado `:ro`, sin puerto publicado, solo `monitoring-network` (lo scrapea Prometheus internamente).
- **cadvisor**: `privileged: true` (patrón estándar de la herramienta), mitigado con todos los mounts en `:ro` y sin puerto expuesto.
- Resto del stack sin cambios: puertos publicados siguen atados a `127.0.0.1`.

## Validación
- `docker compose --profile monitoring config --quiet` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->