### PR TITLE
Update Initializer module to 2.12.0

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -26,7 +26,7 @@
     <!-- track module versions
          we do so here so that we can utilise Maven to track updates, etc. -->
     <openmrs.version>2.8.7</openmrs.version>
-    <initializer.version>2.11.0</initializer.version>
+    <initializer.version>2.12.0</initializer.version>
     <fhir2.version>4.0.0</fhir2.version>
     <webservices.rest.version>3.5.0</webservices.rest.version>
     <addresshierarchy.version>2.21.0</addresshierarchy.version>


### PR DESCRIPTION
## Resumen
- Actualiza initializer-omod de 2.11.0 a 2.12.0.

## Que trae Initializer 2.12.0
- Checksums por fila para dominios CSV, reduciendo recargas innecesarias.
- Soporte para dominio proceduretypes.
- Fixes para conceptsets y lookups de conceptos con `%`.
- Mejora de performance en displays preloaders.

## Compatibilidad
- El dominio proceduretypes requiere emrapi 3.4+ y OpenMRS Core 2.8+.
- Esta distro ya usa emrapi 3.4.0 y OpenMRS 2.8.7.

## Validacion
- Maven versions confirmo initializer.version 2.11.0 -> 2.12.0 antes del cambio.
- No se ejecutaron tests/build completos.
