### PR TITLE
chore: update Initializer 2.12 and content package

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -63,7 +63,7 @@
     <imaging.version>1.2.8</imaging.version>
     <!-- <sihsalus-interop.version>1.0.3</sihsalus-interop.version> -->
     <!-- Content Packages -->
-    <sihsalus-content.version>1.12.2</sihsalus-content.version>
+    <sihsalus-content.version>1.12.4</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
     <reference-demo-content.version>1.8.0-SNAPSHOT</reference-demo-content.version>
   </properties>


### PR DESCRIPTION
## Summary
- Updates the distro to Initializer 2.12.0 and EMR API 3.4.0 support already present in this branch.
- Points SIHSALUS content to version 1.12.4 so the distro can consume the new proceduretypes Initializer content.

## Validation
- mvn -B -f backend/pom.xml help:evaluate -Dexpression=sihsalus-content.version -q -DforceStdout => 1.12.4

Note: full distro dependency resolution requires sihsalus-content 1.12.4 to be published after the content PR is merged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->