### PR TITLE
chore: use sihsalus content 1.12.6

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -63,7 +63,7 @@
     <imaging.version>1.2.8</imaging.version>
     <!-- <sihsalus-interop.version>1.0.3</sihsalus-interop.version> -->
     <!-- Content Packages -->
-    <sihsalus-content.version>1.12.5</sihsalus-content.version>
+    <sihsalus-content.version>1.12.6</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
     <reference-demo-content.version>1.8.0-SNAPSHOT</reference-demo-content.version>
   </properties>


### PR DESCRIPTION
## Summary
- Updates the backend distro to consume `sihsalus-content` version `1.12.6`.
- This picks up the final OCL export bundle from sihsalus-content PR #84.

## Validation
- `mvn -B -f backend/pom.xml help:evaluate -Dexpression=sihsalus-content.version -q -DforceStdout` -> `1.12.6`

Note: full backend validation depends on the `1.12.6` content artifact being published after the content PR is merged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->