### PR TITLE
Correct Spanish spelling in operations docs

### DIFF
--- a/docs/operations/profiles.md
+++ b/docs/operations/profiles.md
@@ -1,20 +1,20 @@
 # Perfiles operativos SIH Salus
 
-Este documento define los perfiles operativos para despliegues de SIH Salus en establecimientos con conectividad limitada. Los perfiles operativos describen realidades de uso; no son solo perfiles tecnicos de Docker Compose.
+Este documento define los perfiles operativos para despliegues de SIH Salus en establecimientos con conectividad limitada. Los perfiles operativos describen realidades de uso; no son solo perfiles técnicos de Docker Compose.
 
 ## Principios
 
 - El perfil por defecto debe permitir atencion clinica local sin internet.
 - Todo servicio habilitado debe tener un responsable operativo claro.
 - Los puestos remotos deben usar la menor cantidad posible de servicios.
-- Las herramientas tecnicas no deben exponerse al personal clinico o administrativo.
+- Las herramientas técnicas no deben exponerse al personal clínico o administrativo.
 - Los paneles de estado no deben mostrar datos personales, datos de salud, tokens ni secretos.
-- El semaforo local debe considerarse un control parcial de disponibilidad, no una certificacion de cumplimiento normativo.
+- El semáforo local debe considerarse un control parcial de disponibilidad, no una certificación de cumplimiento normativo.
 - Las acciones administrativas deben quedar registradas cuando afecten continuidad, seguridad, backup o restauracion.
 
 ## Puesto remoto
 
-Perfil para establecimientos pequenos o aislados donde la prioridad es registrar atenciones y conservar datos localmente.
+Perfil para establecimientos pequeños o aislados donde la prioridad es registrar atenciones y conservar datos localmente.
 
 Servicios habilitados:
 
@@ -83,7 +83,7 @@ Requisitos minimos:
 Politica operativa:
 
 - Keycloak solo debe habilitarse si existe procedimiento local de recuperacion de usuarios.
-- Imaging solo debe habilitarse si hay responsable de almacenamiento y retencion DICOM.
+- Imaging solo debe habilitarse si hay responsable de almacenamiento y retención DICOM.
 - El panel local debe indicar si el sistema puede atender pacientes y si el ultimo backup es valido.
 
 ## Cabecera de microred

--- a/docs/operations/status-compliance.md
+++ b/docs/operations/status-compliance.md
@@ -1,6 +1,6 @@
 # Semaforo local: privacidad y cumplimiento
 
-Este documento define los controles minimos para que el semaforo local de SIH Salus apoye disponibilidad operativa sin procesar datos clinicos ni datos personales.
+Este documento define los controles mínimos para que el semáforo local de SIH Salus apoye disponibilidad operativa sin procesar datos clínicos ni datos personales.
 
 ## Alcance
 


### PR DESCRIPTION
## Summary
- Correct Spanish accent marks in operations profile documentation.
- Correct Spanish accent marks in local status/privacy documentation.

## Validation
- Not run; docs-only spelling changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->