### PR TITLE
Skip backend build for docs-only changes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,8 +3,14 @@ name: Build and Validate Configuration
 on:
   push:
     branches: [pre-release]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   workflow_dispatch:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -177,12 +177,44 @@ Efecto esperado:
 
 
 
+### Relevantar backend sin degradar HTTPS
+
+Regla operativa: usa el mismo set de archivos `-f` y `--profile` con el que levantaste el entorno. En un entorno HTTPS, no ejecutes un `docker compose up -d` genérico sin `compose/ssl.yml`, porque Compose puede reconciliar el servicio `gateway` con la configuración HTTP.
+
+Si solo necesitas reiniciar el proceso del backend:
+
+```bash
+# Stack HTTP/local
+docker compose restart backend
+
+# Stack HTTPS
+docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl restart backend
+```
+
+Si necesitas recrear el contenedor de backend con la configuración e imagen ya presentes, sin tocar `gateway`:
+
+```bash
+# Stack HTTP/local
+docker compose up -d --no-deps --force-recreate backend
+
+# Stack HTTPS
+docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl up -d --no-deps --force-recreate backend
+```
+
+Si el entorno también usa Keycloak u otros overrides, añade esos mismos `-f` y perfiles al comando. La idea es no cambiar la definición efectiva del proyecto durante una operación parcial.
+
 ### Backend (si cambió la imagen del backend)
 
 ```bash
 export BACKEND_TAG=sha-<digest>
+
+# Stack HTTP/local
 docker compose pull backend
 docker compose up -d --no-deps --force-recreate backend
+
+# Stack HTTPS
+docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl pull backend
+docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl up -d --no-deps --force-recreate backend
 ```
 
 Cuando cambie la interfaz de API entre frontend y backend, actualiza primero backend y luego frontend en el mismo ciclo de despliegue.

--- a/compose/README.md
+++ b/compose/README.md
@@ -323,6 +323,20 @@ docker compose \
   up -d
 ```
 
+### Reiniciar backend sin cambiar el modo HTTPS
+
+Usa el mismo set de archivos `-f` y perfiles con el que levantaste el entorno. Si el stack está en HTTPS, no uses un `docker compose up -d` genérico sin `compose/ssl.yml`, porque puede reconciliar `gateway` con la configuración HTTP.
+
+```bash
+# Solo reiniciar proceso
+docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl restart backend
+
+# Recrear backend con la imagen/config actual, sin tocar gateway
+docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl up -d --no-deps --force-recreate backend
+```
+
+Si el entorno incluye Keycloak, agrega también `-f compose/keycloak.yml --profile keycloak`.
+
 ### Stack completo de producción
 ```bash
 docker compose \


### PR DESCRIPTION
## Summary
- Skip the backend build validation workflow for docs-only changes.
- Document how to restart or recreate backend without dropping HTTPS compose overrides.
- Clarify that partial compose operations must use the same -f files and profiles as the running environment.

## Validation
- Not run locally; workflow/docs-only change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->