### PR TITLE
feat: route OpenMRS LiveKit through gateway

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -9,6 +9,7 @@
 #   docker compose up -d                                        # Core
 #   docker compose --profile fua up -d                          # + FUA Generator
 #   docker compose --profile hapi up -d                         # + HAPI FHIR
+#   docker compose --profile ai up -d                           # + OpenMRS LiveKit local AI
 #   docker compose --profile imaging up -d                      # + Imaging (OHIF/Orthanc)
 #   docker compose --profile replica up -d                      # + MariaDB Replica
 #   docker compose -f docker-compose.yml -f compose/openmrs-keycloak.yml --profile keycloak up -d  # + Keycloak Auth
@@ -94,6 +95,37 @@ FRONTEND_RUNTIME_TAG=latest
 # HAPI_DB_USER=hapi
 # HAPI_DB_PASSWORD=                      # OBLIGATORIO - sin default
 # HAPI_DB_NAME=hapi
+
+# ===========================================
+# PROFILE: ai
+# ===========================================
+# Requiere: --profile ai
+# El gateway publica el servicio en /services/openmrs-livekit/.
+
+# OPENMRS_LIVEKIT_IMAGE=ghcr.io/sihsalus/openmrs-livekit
+# OPENMRS_LIVEKIT_TAG=latest
+# OPENMRS_LIVEKIT_API_ENABLED=true
+# OPENMRS_LIVEKIT_API_PORT=8000
+# OPENMRS_LIVEKIT_LOG_LEVEL=INFO
+# OPENMRS_LIVEKIT_LOG_FORMAT=json
+
+# LiveKit local o externo
+# LIVEKIT_URL=ws://livekit:7880
+# LIVEKIT_API_KEY=devkey
+# LIVEKIT_API_SECRET=secret
+
+# Providers actuales del agente. Para el objetivo offline, reemplazar por
+# providers locales cuando el servicio incorpore whisper.cpp/piper/llama.cpp.
+# OPENMRS_LIVEKIT_LLM_PROVIDER=openai
+# OPENMRS_LIVEKIT_STT_PROVIDER=openai
+# OPENMRS_LIVEKIT_TTS_PROVIDER=openai
+# OPENAI_API_KEY=
+# DEEPGRAM_API_KEY=
+
+# Guardrails de privacidad
+# OPENMRS_LIVEKIT_ENABLE_TRANSCRIPT_SAVE=false
+# OPENMRS_LIVEKIT_TRANSCRIPT_REDACTION_ENABLED=true
+# OPENMRS_LIVEKIT_TRANSCRIPT_RAW_STORAGE_ALLOWED=false
 
 # ===========================================
 # PROFILE: monitoring

--- a/compose/README.md
+++ b/compose/README.md
@@ -9,6 +9,7 @@ compose/
 ├── core.yml       # Servicios base (gateway, frontend, backend, db)
 ├── fua.yml        # Generador de Formato Único de Atención (MINSA)
 ├── hapi.yml       # Servidor FHIR para interoperabilidad
+├── openmrs-livekit.yml # Servicio local de IA/voz para OpenMRS LiveKit
 ├── imaging.yml    # Stack médico (OHIF + Orthanc + DICOM)
 ├── replica.yml    # Réplica MariaDB para redundancia/backups
 ├── keycloak.yml   # Autenticación OAuth2/OpenID Connect
@@ -121,6 +122,37 @@ HAPI_DB_NAME=hapi          # Opcional
 - `8085` - HAPI FHIR API (HTTP)
 
 **Base de datos**: PostgreSQL 15
+
+---
+
+### OpenMRS LiveKit (`openmrs-livekit.yml`) - IA local de voz
+
+Servicio opcional para el flujo de traduccion clinica, de-identificacion y revision humana antes de generar borradores OpenMRS. El gateway lo publica en `/services/openmrs-livekit/` y el microfrontend O3 lo consume desde el mismo origen.
+
+**Activar**:
+```bash
+docker compose --profile ai up -d
+```
+
+**Servicios**:
+- `openmrs-livekit` - Agente LiveKit / API local de revision
+
+**Variables principales**:
+```env
+OPENMRS_LIVEKIT_IMAGE=ghcr.io/sihsalus/openmrs-livekit
+OPENMRS_LIVEKIT_TAG=latest
+LIVEKIT_URL=ws://livekit:7880
+LIVEKIT_API_KEY=devkey
+LIVEKIT_API_SECRET=secret
+OPENMRS_LIVEKIT_ENABLE_TRANSCRIPT_SAVE=false
+OPENMRS_LIVEKIT_TRANSCRIPT_REDACTION_ENABLED=true
+```
+
+**Puertos internos**:
+- `8000` - API/metrics del servicio, expuesto solo al gateway
+- `8081` - health server LiveKit del agente
+
+**Nota**: el profile `ai` no publica puertos al host. El acceso de usuario debe pasar por OpenMRS/O3 y el gateway.
 
 ---
 
@@ -357,6 +389,7 @@ Cada profile define volúmenes persistentes para datos:
 | core | `openmrs-data`, mariadb data |
 | fua | `db-fua-generator` (PostgreSQL) |
 | hapi | `hapi_pgdata` (PostgreSQL) |
+| ai | sin volumen persistente por defecto |
 | imaging | `orthanc-data` (DICOM files) |
 | keycloak | `keycloak-data` (PostgreSQL) |
 | monitoring | `grafana-data`, `prometheus-data`, `loki-data` |

--- a/compose/openmrs-livekit.yml
+++ b/compose/openmrs-livekit.yml
@@ -1,0 +1,40 @@
+# Optional local AI voice/translation service for the OpenMRS LiveKit ESM.
+
+services:
+  openmrs-livekit:
+    container_name: sihsalus-openmrs-livekit
+    image: ${OPENMRS_LIVEKIT_IMAGE:-ghcr.io/sihsalus/openmrs-livekit}:${OPENMRS_LIVEKIT_TAG:-latest}
+    restart: "unless-stopped"
+    profiles:
+      - ai
+    expose:
+      - "8000"
+      - "8081"
+    environment:
+      LIVEKIT_URL: ${LIVEKIT_URL:-ws://livekit:7880}
+      LIVEKIT_API_KEY: ${LIVEKIT_API_KEY:-devkey}
+      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:-secret}
+      API_ENABLED: ${OPENMRS_LIVEKIT_API_ENABLED:-true}
+      API_PORT: ${OPENMRS_LIVEKIT_API_PORT:-8000}
+      LOG_LEVEL: ${OPENMRS_LIVEKIT_LOG_LEVEL:-INFO}
+      LOG_FORMAT: ${OPENMRS_LIVEKIT_LOG_FORMAT:-json}
+      LLM_PROVIDER: ${OPENMRS_LIVEKIT_LLM_PROVIDER:-openai}
+      STT_PROVIDER: ${OPENMRS_LIVEKIT_STT_PROVIDER:-openai}
+      TTS_PROVIDER: ${OPENMRS_LIVEKIT_TTS_PROVIDER:-openai}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      DEEPGRAM_API_KEY: ${DEEPGRAM_API_KEY:-}
+      ENABLE_TRANSCRIPT_SAVE: ${OPENMRS_LIVEKIT_ENABLE_TRANSCRIPT_SAVE:-false}
+      TRANSCRIPT_REDACTION_ENABLED: ${OPENMRS_LIVEKIT_TRANSCRIPT_REDACTION_ENABLED:-true}
+      TRANSCRIPT_RAW_STORAGE_ALLOWED: ${OPENMRS_LIVEKIT_TRANSCRIPT_RAW_STORAGE_ALLOWED:-false}
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/metrics', timeout=5)",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@
 #   docker compose up -d                                        # Core (gateway, frontend, backend, db)
 #   docker compose --profile fua up -d                          # + FUA Generator
 #   docker compose --profile hapi up -d                         # + HAPI FHIR Server
+#   docker compose --profile ai up -d                           # + OpenMRS LiveKit local AI
 #   docker compose --profile imaging up -d                      # + Medical Imaging (OHIF/Orthanc)
 #   docker compose -f docker-compose.yml -f compose/keycloak.yml --profile keycloak up -d  # + Keycloak Auth
 #   docker compose --profile monitoring up -d                   # + Observability (Grafana/Prometheus/Loki)
@@ -32,6 +33,8 @@ include:
   - path: compose/fua.yml
     project_directory: .
   - path: compose/hapi.yml
+    project_directory: .
+  - path: compose/openmrs-livekit.yml
     project_directory: .
   - path: compose/imaging.yml
     project_directory: .

--- a/gateway/default-ssl.conf.template
+++ b/gateway/default-ssl.conf.template
@@ -14,6 +14,11 @@ map $http_x_real_ip $forwarded_ip {
   default $remote_addr;
 }
 
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
 upstream backend {
   server backend:8080 max_fails=0;
 }
@@ -62,7 +67,7 @@ server {
   add_header X-Content-Type-Options "nosniff" always;
   add_header Content-Security-Policy $csp_header always;
   add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-  add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+  add_header Permissions-Policy "geolocation=(), microphone=(self), camera=()" always;
 
   # Proxy settings with secure cookies
   proxy_set_header      HOST $host;
@@ -264,6 +269,30 @@ server {
     set $orthanc_proxy http://orthanc-proxy;
     proxy_read_timeout 300s;
     proxy_pass $orthanc_proxy;
+  }
+
+  # Local AI voice/translation service consumed by the OpenMRS LiveKit ESM.
+  location = /services/openmrs-livekit {
+    return 301 /services/openmrs-livekit/;
+  }
+
+  location /services/openmrs-livekit/ {
+    set $openmrs_livekit http://openmrs-livekit:8000;
+    rewrite ^/services/openmrs-livekit/(.*)$ /$1 break;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_buffering off;
+    proxy_read_timeout 300s;
+    proxy_pass $openmrs_livekit;
+    proxy_intercept_errors on;
+    error_page 502 503 504 = @openmrs_livekit_unavailable;
+  }
+
+  location @openmrs_livekit_unavailable {
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header Content-Type "application/json" always;
+    add_header Retry-After 30 always;
+    return 503 '{"error":"OpenMRS LiveKit service is temporarily unavailable","status":503}';
   }
 
   # FUA Generator Service

--- a/gateway/default.conf.template
+++ b/gateway/default.conf.template
@@ -19,6 +19,11 @@ map $http_x_real_ip $forwarded_ip {
   default $remote_addr;
 }
 
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
 upstream backend {
   server backend:8080 max_fails=0;
 }
@@ -237,6 +242,29 @@ server {
     set $orthanc_proxy http://orthanc-proxy;
     proxy_read_timeout 300s;
     proxy_pass $orthanc_proxy;
+  }
+
+  # Local AI voice/translation service consumed by the OpenMRS LiveKit ESM.
+  location = /services/openmrs-livekit {
+    return 301 /services/openmrs-livekit/;
+  }
+
+  location /services/openmrs-livekit/ {
+    set $openmrs_livekit http://openmrs-livekit:8000;
+    rewrite ^/services/openmrs-livekit/(.*)$ /$1 break;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_buffering off;
+    proxy_read_timeout 300s;
+    proxy_pass $openmrs_livekit;
+    proxy_intercept_errors on;
+    error_page 502 503 504 = @openmrs_livekit_unavailable;
+  }
+
+  location @openmrs_livekit_unavailable {
+    default_type application/json;
+    add_header Retry-After 30 always;
+    return 503 '{"error":"OpenMRS LiveKit service is temporarily unavailable","status":503}';
   }
 
   ${FUA_LOCATIONS}


### PR DESCRIPTION
Adds the optional OpenMRS LiveKit AI profile and exposes the local service through the gateway for the OpenMRS LiveKit microfrontend.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->