### PR TITLE
Use SIHSALUS content package 1.14.1

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -62,7 +62,7 @@
     <fua.version>1.0.79</fua.version>
     <imaging.version>1.2.8</imaging.version>
     <!-- Content Packages -->
-    <sihsalus-content.version>1.14.0</sihsalus-content.version>
+    <sihsalus-content.version>1.14.1</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
     <reference-demo-content.version>1.8.0-SNAPSHOT</reference-demo-content.version>
   </properties>


### PR DESCRIPTION
## Summary
- Update SIHSALUS content package from 1.14.0 to 1.14.1.

## Context
The 1.14.1 content package adds the 2026-06-17 prestacional OCL export, updates laboratory reference ranges, and adjusts app roles/privileges.

## Validation
- Confirmed the 1.14.1 artifact is published in Maven Central during review.
- No local build run; this should be validated by CI and environment smoke testing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->