### PR TITLE
Preserve multiple SPA config URLs

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,12 +17,14 @@ ENV SPA_OUTPUT_DIR=/tmp/spa \
     SPA_CONFIG_URLS=${SPA_CONFIG_URLS} \
     SPA_DEFAULT_LOCALE=${SPA_DEFAULT_LOCALE}
 
+COPY patch-config-urls.js /app/patch-config-urls.js
 COPY frontend-keycloak.json /app/config/frontend-keycloak.json
 
 RUN test -n "$SPA_CONFIG_URLS" || { echo "SPA_CONFIG_URLS build arg is required; define it in compose/core.yml"; exit 1; } \
     && rm -rf "$SPA_OUTPUT_DIR" \
     && mkdir -p "$SPA_OUTPUT_DIR" \
     && node packages/tooling/scripts/assemble-importmap.js \
+    && node /app/patch-config-urls.js \
     && if [ "$STRIP_SOURCE_MAPS" = "true" ]; then \
          find "$SPA_OUTPUT_DIR" -type f -name "*.map" -delete; \
        fi

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -18,6 +18,7 @@ El frontend es una Single Page Application (SPA) moderna construida con React y 
 frontend/
 ├── Dockerfile         # Construye la imagen runtime versionada
 ├── nginx.conf         # Configuración Nginx para SPA
+├── patch-config-urls.js # Adapta SPA_CONFIG_URLS al index.html
 └── frontend-keycloak.json
 ```
 
@@ -92,7 +93,7 @@ sendfile on;                        # Zero-copy para archivos estáticos
 | `FRONTEND_SOURCE_IMAGE` | `ghcr.io/sihsalus/sihsalus-frontend:latest` | Imagen fuente con bundles y ensamblador |
 | `SPA_PATH` | `/openmrs/spa` | Path en el que está disponible la SPA |
 | `API_URL` | `/openmrs` | URL base para llamadas a API backend |
-| `SPA_CONFIG_URLS` | `/openmrs/spa/frontend.json` | Ubicación del config JSON. Fuente de verdad: `compose/core.yml` |
+| `SPA_CONFIG_URLS` | `/openmrs/spa/frontend.json` | Ubicación del config JSON. Fuente de verdad: `compose/core.yml`. Acepta varios JSON separados por coma |
 | `SPA_DEFAULT_LOCALE` | `es` | Idioma por defecto (es, en, pt, fr, etc.) |
 
 ### Archivos de Configuración SPA

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -93,7 +93,7 @@ sendfile on;                        # Zero-copy para archivos estáticos
 | `FRONTEND_SOURCE_IMAGE` | `ghcr.io/sihsalus/sihsalus-frontend:latest` | Imagen fuente con bundles y ensamblador |
 | `SPA_PATH` | `/openmrs/spa` | Path en el que está disponible la SPA |
 | `API_URL` | `/openmrs` | URL base para llamadas a API backend |
-| `SPA_CONFIG_URLS` | `/openmrs/spa/frontend.json` | Ubicación del config JSON. Fuente de verdad: `compose/core.yml`. Acepta varios JSON separados por coma |
+| `SPA_CONFIG_URLS` | `/openmrs/spa/frontend.json` | Ubicación del config JSON. Fuente de verdad: `compose/core.yml`. Acepta varios JSON separados por coma; los duplicados se ignoran |
 | `SPA_DEFAULT_LOCALE` | `es` | Idioma por defecto (es, en, pt, fr, etc.) |
 
 ### Archivos de Configuración SPA

--- a/frontend/patch-config-urls.js
+++ b/frontend/patch-config-urls.js
@@ -15,10 +15,12 @@ if (!fs.existsSync(indexPath)) {
   process.exit(1);
 }
 
-const configUrls = rawConfigUrls
-  .split(',')
-  .map((url) => url.trim())
-  .filter(Boolean);
+const configUrls = Array.from(new Set(
+  rawConfigUrls
+    .split(',')
+    .map((url) => url.trim())
+    .filter(Boolean)
+));
 
 if (configUrls.length === 0) {
   console.error('[patch-config-urls] SPA_CONFIG_URLS did not contain any usable config URL');

--- a/frontend/patch-config-urls.js
+++ b/frontend/patch-config-urls.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+const outDir = process.env.SPA_OUTPUT_DIR || '/spa';
+const indexPath = path.join(outDir, 'index.html');
+const rawConfigUrls = (process.env.SPA_CONFIG_URLS || '').trim();
+
+if (!rawConfigUrls) {
+  console.error('[patch-config-urls] SPA_CONFIG_URLS is required');
+  process.exit(1);
+}
+
+if (!fs.existsSync(indexPath)) {
+  console.error(`[patch-config-urls] ${indexPath} not found`);
+  process.exit(1);
+}
+
+const configUrls = rawConfigUrls
+  .split(',')
+  .map((url) => url.trim())
+  .filter(Boolean);
+
+if (configUrls.length === 0) {
+  console.error('[patch-config-urls] SPA_CONFIG_URLS did not contain any usable config URL');
+  process.exit(1);
+}
+
+const replacement = `configUrls: ${JSON.stringify(configUrls)}`;
+const html = fs.readFileSync(indexPath, 'utf8');
+const nextHtml = html.replace(/configUrls:\s*\[[^\]]*\]/, replacement);
+
+if (nextHtml === html) {
+  console.error('[patch-config-urls] configUrls initializer not found in index.html');
+  process.exit(1);
+}
+
+fs.writeFileSync(indexPath, nextHtml);
+console.log(`[patch-config-urls] ${replacement}`);


### PR DESCRIPTION
## Summary
- restore patch-config-urls as a generic adapter for SPA_CONFIG_URLS
- preserve support for multiple config JSON URLs
- deduplicate config URLs while preserving order

## Context
Direct push to main was rejected by branch protection, so this PR carries the missing local commits.

## Testing
- Not run (not requested).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->