### PR TITLE
chore: update content package and FHIR2 module

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -27,7 +27,7 @@
          we do so here so that we can utilise Maven to track updates, etc. -->
     <openmrs.version>2.8.7</openmrs.version>
     <initializer.version>2.12.0</initializer.version>
-    <fhir2.version>4.0.0</fhir2.version>
+    <fhir2.version>4.1.0</fhir2.version>
     <webservices.rest.version>3.5.0</webservices.rest.version>
     <addresshierarchy.version>2.21.0</addresshierarchy.version>
     <patientdocuments.version>1.1.0</patientdocuments.version>
@@ -62,7 +62,7 @@
     <fua.version>1.0.80</fua.version>
     <imaging.version>1.2.8</imaging.version>
     <!-- Content Packages -->
-    <sihsalus-content.version>1.14.2</sihsalus-content.version>
+    <sihsalus-content.version>1.14.7</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
     <reference-demo-content.version>1.8.0-SNAPSHOT</reference-demo-content.version>
   </properties>


### PR DESCRIPTION
## Resumen
- Actualiza sihsalus-content.version de 1.14.2 a 1.14.7.
- Actualiza fhir2.version de 4.0.0 a 4.1.0.

## Revision de OMODs
Ejecute el chequeo Maven con las reglas del repo:

    mvn -f backend/pom.xml versions:display-property-updates -Dmaven.version.rules=file:///private/tmp/sihsalus-main/backend/version-rules.xml

Antes del cambio, el unico update permitido/recomendado era fhir2.version 4.0.0 -> 4.1.0. Despues del cambio, Maven reporta que todos los version properties apuntan a la version mas nueva disponible bajo esas reglas.

FHIR2 4.1.0 es release oficial de OpenMRS publicada el 2026-06-26. Los cambios son acotados: soporte para Task.focus, estados adicionales de Task (Draft, In Progress) y un fix de autorizacion en metodos sobrescritos.

## Verificacion
- mvn --batch-mode --update-snapshots --file backend/pom.xml clean package
- mvn -f backend/pom.xml versions:display-property-updates -Dmaven.version.rules=file:///private/tmp/sihsalus-main/backend/version-rules.xml

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->