### PR TITLE
Fix FUA secret and OAuth redirect config

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -62,6 +62,7 @@ FRONTEND_RUNTIME_TAG=latest
 # SIHSALUS_FUA_GEN_DB_PASSWORD=          # OBLIGATORIO - sin default
 # SIHSALUS_FUA_GEN_DB=fuagenerator
 # SIHSALUS_FUA_GEN_TOKEN=                # OBLIGATORIO - sin default
+# SIHSALUS_FUA_GEN_SECRET_KEY=           # OBLIGATORIO - sin default en entornos compartidos/prod
 
 # Routing nginx para FUA (pegar el bloque upstream/location como valor)
 # FUA_CONFIG=

--- a/compose/README.md
+++ b/compose/README.md
@@ -86,6 +86,7 @@ docker compose --profile fua up -d
 ```env
 SIHSALUS_FUA_GEN_DB_PASSWORD=<password>
 SIHSALUS_FUA_GEN_TOKEN=<token_acceso_fua>
+SIHSALUS_FUA_GEN_SECRET_KEY=<secret_fua>
 FUA_CONFIG=<configuracion_json>    # En gateway env vars
 FUA_LOCATIONS=<ubicaciones_json>   # En gateway env vars
 ```

--- a/compose/fua.yml
+++ b/compose/fua.yml
@@ -15,6 +15,7 @@ services:
       DB_PASSWORD: ${SIHSALUS_FUA_GEN_DB_PASSWORD:-fuagenerator}
       DB_NAME: ${SIHSALUS_FUA_GEN_DB:-fuagenerator}
       TOKEN: ${SIHSALUS_FUA_GEN_TOKEN:-fuagenerator}
+      SECRET_KEY: ${SIHSALUS_FUA_GEN_SECRET_KEY:-change-me}
       DB_HOST: "fua-generator-db"
       DB_PORT: "5432"
     depends_on:

--- a/frontend/patch-config-urls.js
+++ b/frontend/patch-config-urls.js
@@ -29,12 +29,13 @@ if (configUrls.length === 0) {
 
 const replacement = `configUrls: ${JSON.stringify(configUrls)}`;
 const html = fs.readFileSync(indexPath, 'utf8');
-const nextHtml = html.replace(/configUrls:\s*\[[^\]]*\]/, replacement);
+const configUrlsPattern = /configUrls:\s*\[[^\]]*\]/;
 
-if (nextHtml === html) {
+if (!configUrlsPattern.test(html)) {
   console.error('[patch-config-urls] configUrls initializer not found in index.html');
   process.exit(1);
 }
 
+const nextHtml = html.replace(configUrlsPattern, replacement);
 fs.writeFileSync(indexPath, nextHtml);
 console.log(`[patch-config-urls] ${replacement}`);

--- a/keycloak/openmrs_config/globalproperties/oauth2login.xml
+++ b/keycloak/openmrs_config/globalproperties/oauth2login.xml
@@ -2,7 +2,7 @@
     <globalProperties>
         <globalProperty>
             <property>oauth2login.redirectUriAfterLogin</property>
-            <value>/spa/home</value>
+            <value>/openmrs/spa/home</value>
             <description>Redirect target after successful OAuth2 login.</description>
         </globalProperty>
     </globalProperties>


### PR DESCRIPTION
## Summary
- Add FUA generator SECRET_KEY wiring and document SIHSALUS_FUA_GEN_SECRET_KEY.
- Fix OAuth2 post-login redirect to include the /openmrs prefix.
- Make frontend config URL patching fail explicitly when the initializer is missing.

## Validation
- Not run locally; config-only changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->