### PR TITLE
Validate compose profiles in CI

### DIFF
--- a/.github/workflows/validate-compose.yml
+++ b/.github/workflows/validate-compose.yml
@@ -46,6 +46,7 @@ jobs:
           docker compose --profile hapi config --quiet
           docker compose --profile imaging config --quiet
           docker compose --profile indicadores config --quiet
+          docker compose --profile keycloak config --quiet
           docker compose --profile monitoring --profile logs config --quiet
           docker compose --profile replica config --quiet
 

--- a/.github/workflows/validate-compose.yml
+++ b/.github/workflows/validate-compose.yml
@@ -1,0 +1,57 @@
+name: Validate Compose Configuration
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/validate-compose.yml'
+      - '.env.template'
+      - 'docker-compose.yml'
+      - 'compose/**'
+      - 'gateway/**'
+      - 'frontend/**'
+      - 'keycloak/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/validate-compose.yml'
+      - '.env.template'
+      - 'docker-compose.yml'
+      - 'compose/**'
+      - 'gateway/**'
+      - 'frontend/**'
+      - 'keycloak/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compose-config:
+    name: Validate Docker Compose config
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Validate core stack
+        run: docker compose config --quiet
+
+      - name: Validate optional profiles
+        run: |
+          docker compose --profile fua config --quiet
+          docker compose --profile hapi config --quiet
+          docker compose --profile imaging config --quiet
+          docker compose --profile indicadores config --quiet
+          docker compose --profile monitoring --profile logs config --quiet
+          docker compose --profile replica config --quiet
+
+      - name: Validate standalone overrides
+        run: |
+          docker compose -f docker-compose.yml -f compose/keycloak.yml --profile keycloak config --quiet
+          docker compose -f docker-compose.yml -f compose/status.yml --profile status config --quiet
+          docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl config --quiet
+          docker compose -f docker-compose.yml -f compose/keycloak.yml -f compose/ssl.yml --profile keycloak --profile ssl config --quiet

--- a/.github/workflows/validate-compose.yml
+++ b/.github/workflows/validate-compose.yml
@@ -52,7 +52,6 @@ jobs:
 
       - name: Validate standalone overrides
         run: |
-          docker compose -f docker-compose.yml -f compose/keycloak.yml --profile keycloak config --quiet
           docker compose -f docker-compose.yml -f compose/status.yml --profile status config --quiet
           docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl config --quiet
           docker compose -f docker-compose.yml -f compose/ssl.yml --profile keycloak --profile ssl config --quiet

--- a/.github/workflows/validate-compose.yml
+++ b/.github/workflows/validate-compose.yml
@@ -49,6 +49,7 @@ jobs:
           docker compose --profile keycloak config --quiet
           docker compose --profile monitoring --profile logs config --quiet
           docker compose --profile replica config --quiet
+          docker compose --profile keycloak config --quiet
 
       - name: Validate standalone overrides
         run: |

--- a/.github/workflows/validate-compose.yml
+++ b/.github/workflows/validate-compose.yml
@@ -55,4 +55,4 @@ jobs:
           docker compose -f docker-compose.yml -f compose/keycloak.yml --profile keycloak config --quiet
           docker compose -f docker-compose.yml -f compose/status.yml --profile status config --quiet
           docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl config --quiet
-          docker compose -f docker-compose.yml -f compose/keycloak.yml -f compose/ssl.yml --profile keycloak --profile ssl config --quiet
+          docker compose -f docker-compose.yml -f compose/ssl.yml --profile keycloak --profile ssl config --quiet


### PR DESCRIPTION
## Summary
- Add a dedicated Compose validation workflow.
- Validate core compose config, optional profiles, standalone overrides, and Keycloak+SSL composition.
- Run on main pushes and PRs that touch compose/gateway/frontend/keycloak/env workflow inputs.

## Validation
- Not run locally; this PR adds the CI check itself.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->