### PR TITLE
fix: remove duplicate SECRET_KEY environment variable in fua.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ docker compose --profile fua --profile hapi --profile monitoring up -d
 # Core + SSL/HTTPS (override especial; requiere cargar compose/ssl.yml)
 docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl up -d
 
+# Core + SSL/HTTPS + FUA:
+docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl --profile fua up -d
+
 # Core + Keycloak Auth + SSL/HTTPS
 docker compose -f docker-compose.yml -f compose/keycloak.yml -f compose/ssl.yml --profile keycloak --profile ssl up -d
 ```


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->