### PR TITLE
Add OpenMRS seed restore profile

### DIFF
--- a/compose/seed.yml
+++ b/compose/seed.yml
@@ -20,7 +20,7 @@ services:
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
     entrypoint: [ "/bin/sh", "/usr/local/bin/apply-seed.sh" ]
     volumes:
-      - ../scripts/seed/apply-seed.sh:/usr/local/bin/apply-seed.sh:ro
+      - ./scripts/seed/apply-seed.sh:/usr/local/bin/apply-seed.sh:ro
       - db-data:/seed/db-data
       - openmrs-data:/seed/openmrs-data
       - db-fua-generator:/seed/fua-db-data

--- a/compose/seed.yml
+++ b/compose/seed.yml
@@ -1,0 +1,31 @@
+# One-shot seed restore from a GitHub Release artifact.
+#
+# Usage:
+#   SIHSALUS_SEED_URL=https://github.com/sihsalus/sihsalus/releases/download/<tag>/sihsalus-seed.tar.gz \
+#   docker compose -f docker-compose.yml -f compose/seed.yml --profile seed up -d
+#
+# To replace existing volumes:
+#   SIHSALUS_SEED_FORCE=true ...
+
+services:
+  seed:
+    image: curlimages/curl:8.10.1
+    user: "0:0"
+    profiles: [ "seed" ]
+    restart: "no"
+    environment:
+      SIHSALUS_SEED_URL: ${SIHSALUS_SEED_URL:-}
+      SIHSALUS_SEED_SHA256: ${SIHSALUS_SEED_SHA256:-}
+      SIHSALUS_SEED_FORCE: ${SIHSALUS_SEED_FORCE:-false}
+      GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+    entrypoint: [ "/bin/sh", "/usr/local/bin/apply-seed.sh" ]
+    volumes:
+      - ../scripts/seed/apply-seed.sh:/usr/local/bin/apply-seed.sh:ro
+      - db-data:/seed/db-data
+      - openmrs-data:/seed/openmrs-data
+      - db-fua-generator:/seed/fua-db-data
+
+  db:
+    depends_on:
+      seed:
+        condition: service_completed_successfully

--- a/docs/operations/profiles.md
+++ b/docs/operations/profiles.md
@@ -195,4 +195,7 @@ Restricciones:
 - Toda actualizacion debe dejar version anterior, version nueva, operador, fecha y resultado.
 - Todo backup debe poder verificarse por fecha, checksum y resultado.
 
-Ver tambien: [Semaforo local: privacidad y cumplimiento](status-compliance.md).
+Ver tambien:
+
+- [Semaforo local: privacidad y cumplimiento](status-compliance.md)
+- [Metricas de seed restore y arranque OpenMRS](seed-restore-metrics.md)

--- a/docs/operations/seed-restore-metrics.md
+++ b/docs/operations/seed-restore-metrics.md
@@ -1,0 +1,55 @@
+# Metricas de seed restore y arranque OpenMRS
+
+Medicion tomada el 2026-07-03 en `gidis-dev` y comparada con arranques recientes de `gidis-qlty`.
+
+## Baseline de contenido
+
+- Artifact: `seed-content-6c25fe8-backend-d61608b-r2`
+- Tamano descargado: 455 MB
+- SHA256: `cbd4f984480ccac57b9fca0c913dd1fc797c7a45b4059ff6b3046d7eeffb620d`
+- Conteos esperados despues del restore:
+  - `concept`: 32376
+  - `openconceptlab_item` mappings: 20003
+  - OCL errors: 0
+  - `patient`: 0
+  - `obs`: 0
+  - `encounter`: 0
+
+## Tiempos medidos en dev
+
+| Paso | Tiempo medido | Evidencia |
+| --- | ---: | --- |
+| Descargar artifact seed desde GitHub Releases | 22 s | `curl` dentro de `sihsalus-seed-1` |
+| Restore completo de volumenes seed | 1 min 02 s | `StartedAt=2026-07-03T15:23:45Z`, `FinishedAt=2026-07-03T15:24:47Z` |
+| Build backend local con cache Maven fria/parcial | aprox. 11-12 min | `dependency:resolve` 7m12s, `mvn install` 2m59s, export/capas aprox. 1m |
+| Recreate backend despues del build | 10-15 s | Compose recreo `sihsalus-backend` y arranco contenedor |
+| Startup backend/OpenMRS hasta Tomcat listo | 11 min 34 s | `StartedAt=2026-07-03T15:48:36Z`, `Server startup=2026-07-03T16:00:10Z` |
+| `Refreshing Context` de OpenMRS | 7 min 59 s | `15:50:03Z` a `15:58:02Z` |
+| Validacion final backend | 200 | `GET /openmrs/health/started` |
+
+## Comparacion QLTY
+
+Arranques recientes con contenido cargado:
+
+| Ambiente | Refresh context | Tomcat startup total |
+| --- | ---: | ---: |
+| QLTY | 7 min 26 s | 10 min 42 s |
+| QLTY | 8 min 04 s | 12 min 02 s |
+| DEV | 7 min 59 s | 11 min 34 s |
+
+## Regla operativa
+
+- Seed restore desde artifact debe tomar alrededor de 1-2 minutos con red normal.
+- Backend/OpenMRS puede tardar 10-12 minutos en quedar `healthy` despues de recrear imagen o contenedor.
+- Durante el arranque es normal ver CPU alta y el ultimo log en `Refreshing Context`.
+- No reiniciar si el proceso sigue consumiendo CPU y no hay stacktrace nuevo; reiniciar solo vuelve a empezar el warmup.
+- Investigar si pasan mas de 15 minutos sin `Server startup`, si CPU cae a casi 0 sin health `200`, o si aparecen errores repetidos de Spring/beans en logs.
+
+## Comandos rapidos
+
+```bash
+docker ps --format "table {{.Names}}\t{{.Status}}"
+docker logs --tail 120 sihsalus-backend
+docker exec sihsalus-backend curl --max-time 10 -sS -o /dev/null -w "BACKEND=%{http_code}\n" http://localhost:8080/openmrs/health/started
+docker exec sihsalus-db-master sh -lc 'mariadb --user="$MYSQL_USER" --password="$MYSQL_PASSWORD" openmrs -N -e "SELECT COUNT(*) FROM concept; SELECT COUNT(*) FROM openconceptlab_item WHERE type=CHAR(77,65,80,80,73,78,71); SELECT COUNT(*) FROM openconceptlab_item WHERE error_message IS NOT NULL AND LENGTH(error_message)>0; SELECT COUNT(*) FROM patient; SELECT COUNT(*) FROM obs; SELECT COUNT(*) FROM encounter;"'
+```

--- a/scripts/seed/apply-seed.sh
+++ b/scripts/seed/apply-seed.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -eu
+
+SEED_URL="${SIHSALUS_SEED_URL:-}"
+SEED_SHA256="${SIHSALUS_SEED_SHA256:-}"
+SEED_FORCE="${SIHSALUS_SEED_FORCE:-false}"
+TMP_DIR="/tmp/sihsalus-seed"
+SEED_FILE="$TMP_DIR/seed.tar.gz"
+WORK_DIR="$TMP_DIR/work"
+
+has_data() {
+  find "$1" -mindepth 1 -maxdepth 1 | read _unused
+}
+
+empty_dir() {
+  rm -rf "$1"/* "$1"/.[!.]* "$1"/..?* 2>/dev/null || true
+}
+
+extract_volume() {
+  archive="$1"
+  dest="$2"
+  label="$3"
+
+  if has_data "$dest"; then
+    if [ "$SEED_FORCE" = "true" ]; then
+      echo "[seed] clearing $label volume"
+      empty_dir "$dest"
+    else
+      echo "[seed] $label volume already has data; set SIHSALUS_SEED_FORCE=true to replace it"
+      return 0
+    fi
+  fi
+
+  echo "[seed] extracting $label"
+  tar xzf "$archive" -C "$dest"
+}
+
+[ -n "$SEED_URL" ] || {
+  echo "[seed] SIHSALUS_SEED_URL is required"
+  exit 2
+}
+
+rm -rf "$TMP_DIR"
+mkdir -p "$WORK_DIR"
+
+echo "[seed] downloading $SEED_URL"
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  curl -fL \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -H "Accept: application/octet-stream" \
+    -o "$SEED_FILE" \
+    "$SEED_URL"
+else
+  curl -fL -o "$SEED_FILE" "$SEED_URL"
+fi
+
+if [ -n "$SEED_SHA256" ]; then
+  echo "$SEED_SHA256  $SEED_FILE" | sha256sum -c -
+fi
+
+tar xzf "$SEED_FILE" -C "$WORK_DIR"
+
+[ -f "$WORK_DIR/db-data.tar.gz" ] || { echo "[seed] missing db-data.tar.gz"; exit 3; }
+[ -f "$WORK_DIR/openmrs-data.tar.gz" ] || { echo "[seed] missing openmrs-data.tar.gz"; exit 3; }
+
+extract_volume "$WORK_DIR/db-data.tar.gz" /seed/db-data "db-data"
+extract_volume "$WORK_DIR/openmrs-data.tar.gz" /seed/openmrs-data "openmrs-data"
+
+if [ -f "$WORK_DIR/fua-db-data.tar.gz" ]; then
+  extract_volume "$WORK_DIR/fua-db-data.tar.gz" /seed/fua-db-data "fua-db-data"
+fi
+
+date -u +"%Y-%m-%dT%H:%M:%SZ" > /seed/openmrs-data/.sihsalus-seed-applied
+echo "[seed] done"


### PR DESCRIPTION
Adds a minimal Compose seed profile that downloads a sanitized OpenMRS seed artifact from SIHSALUS_SEED_URL and restores db-data/openmrs-data/FUA volumes before DB/backend start.\n\nSeed release created: https://github.com/sihsalus/sihsalus/releases/tag/seed-content-6c25fe8-backend-d61608b\n\nValidation run locally:\n- sh -n scripts/seed/apply-seed.sh\n- docker compose -f docker-compose.yml -f compose/seed.yml --profile seed config --services

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->