### PR TITLE
Import refapp hardening for image signing and module versions

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -22,6 +22,7 @@ jobs:
     timeout-minutes: 90
     permissions:
       contents: read
+      id-token: write
       packages: write
     steps:
       - uses: actions/checkout@v7
@@ -43,6 +44,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: .
           file: backend/Dockerfile
@@ -52,6 +54,14 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha,scope=backend
           cache-to: type=gha,scope=backend,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.9.2
+
+      - name: Sign image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "ghcr.io/sihsalus/sihsalus-backend@${DIGEST}"
 
       - name: Make package public
         run: |

--- a/.github/workflows/build-certbot.yml
+++ b/.github/workflows/build-certbot.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
       packages: write
     steps:
       - uses: actions/checkout@v7
@@ -39,6 +40,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: ./certbot
           push: true
@@ -47,6 +49,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha,scope=certbot
           cache-to: type=gha,scope=certbot,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.9.2
+
+      - name: Sign image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "ghcr.io/sihsalus/sihsalus-certbot@${DIGEST}"
 
       - name: Make package public
         run: |

--- a/.github/workflows/build-gateway.yml
+++ b/.github/workflows/build-gateway.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
       packages: write
     steps:
       - uses: actions/checkout@v7
@@ -39,6 +40,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: ./gateway
           push: true
@@ -47,6 +49,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha,scope=gateway
           cache-to: type=gha,scope=gateway,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.9.2
+
+      - name: Sign image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "ghcr.io/sihsalus/sihsalus-gateway@${DIGEST}"
 
       - name: Make package public
         run: |

--- a/.github/workflows/build-monitoring-init.yml
+++ b/.github/workflows/build-monitoring-init.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
       packages: write
     steps:
       - uses: actions/checkout@v7
@@ -39,6 +40,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: ./monitoring
           push: true
@@ -47,6 +49,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha,scope=monitoring
           cache-to: type=gha,scope=monitoring,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.9.2
+
+      - name: Sign image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "ghcr.io/sihsalus/sihsalus-monitoring@${DIGEST}"
 
       - name: Make package public
         run: |

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -38,8 +38,8 @@
     <attachments.version>4.0.0</attachments.version>
     <referencedemodata.version>2.6.1</referencedemodata.version>
     <queue.version>3.0.0</queue.version>
-    <appointments.version>2.1.0-20250318.070530-1</appointments.version>
-    <teleconsultation.version>2.1.0-20250318.154145-1</teleconsultation.version>
+    <appointments.version>2.1.0</appointments.version>
+    <teleconsultation.version>2.0.0</teleconsultation.version>
     <cohort.version>3.7.3</cohort.version>
     <authentication.version>2.3.0</authentication.version>
     <oauth2login.version>1.5.0</oauth2login.version>


### PR DESCRIPTION
## Summary
- switch appointments and teleconsultation modules from timestamped snapshot builds to released versions, matching upstream OpenMRS RefApp hardening
- sign GHCR-published backend, gateway, certbot, and monitoring images with cosign keyless signing
- grant workflow OIDC token permissions required for cosign

## Validation
- git diff --check
- parsed touched workflow YAML with Ruby YAML loader
- mvn --batch-mode --file backend/pom.xml help:evaluate -Dexpression=appointments.version -DforceStdout -q
- mvn --batch-mode --file backend/pom.xml help:evaluate -Dexpression=teleconsultation.version -DforceStdout -q
- mvn --batch-mode --file backend/pom.xml -DskipTests dependency:resolve

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->