### PR TITLE
Add production Let's Encrypt certbot flow

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -109,11 +109,15 @@ FRONTEND_RUNTIME_TAG=latest
 # ===========================================
 
 # SSL_MODE=dev
-# CERT_WEB_DOMAIN_COMMON_NAME=localhost
 # CERT_WEB_DOMAINS=localhost,127.0.0.1
+# CERT_WEB_DOMAIN_COMMON_NAME=          # Opcional; por defecto usa el primer CERT_WEB_DOMAINS
+# CERT_CONTACT_EMAIL=                   # Recomendado con SSL_MODE=prod
+# SSL_STAGING=false                     # true para probar Let's Encrypt sin rate limits
+# CERT_PROFILE=                         # classic, tlsserver o shortlived; IP publica usa shortlived
 # CERT_RSA_KEY_SIZE=2048
 # CERT_TEMP_CERT_DAYS=365
-# CERT_RENEWAL_INTERVAL=30d
+# CERT_NGINX_STARTUP_WAIT=10
+# CERT_RENEWAL_INTERVAL=12h
 # CERT_ORG=Centro de Salud
 # CERT_OU=sihsalus
 # CERT_COUNTRY=PE

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![License](https://img.shields.io/badge/MPL_2.0-brightgreen?style=flat-square&label=License)
 
 > SIH Salus es una distribución OpenMRS 3.x para establecimientos de salud del Perú.
-> Certificados SSL auto-firmados, despliegue offline, backups cifrados.
+> SSL auto-firmado o Let's Encrypt, despliegue offline, backups cifrados.
 
 ---
 
@@ -277,16 +277,19 @@ Alternativamente, `docker compose build` sigue funcionando.
 
 ## Configuración SSL/HTTPS
 
-SIHSALUS genera certificados SSL auto-firmados, pensados para redes hospitalarias internas sin acceso a internet.
+SIH Salus soporta dos modos HTTPS:
 
-No se requiere un dominio público ni una autoridad certificadora externa. El sistema genera su propio certificado al iniciar por primera vez.
+- `SSL_MODE=dev`: certificados auto-firmados para redes internas u offline.
+- `SSL_MODE=prod`: certificados reales de Let's Encrypt usando HTTP-01 y renovación automática.
 
-### Iniciar con SSL
+`compose/ssl.yml` debe cargarse con `-f` porque no está incluido por defecto en `docker-compose.yml`. El flag `--profile ssl` activa el servicio `certbot` definido en ese archivo; sin el `-f compose/ssl.yml`, Compose no ve ese profile ni aplica los cambios de `gateway` para publicar el puerto 443.
+
+### SSL interno auto-firmado
 
 Agregar las variables SSL al `.env`:
 
 ```env
-CERT_WEB_DOMAIN_COMMON_NAME=192.168.10.5
+SSL_MODE=dev
 CERT_WEB_DOMAINS=192.168.10.5,localhost,127.0.0.1
 ```
 
@@ -297,7 +300,30 @@ docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl up -d
 # https://192.168.10.5/openmrs/spa
 ```
 
-`compose/ssl.yml` debe cargarse con `-f` porque no está incluido por defecto en `docker-compose.yml`. El flag `--profile ssl` activa el servicio `certbot` definido en ese archivo; sin el `-f compose/ssl.yml`, Compose no ve ese profile ni aplica los cambios de `gateway` para publicar el puerto 443.
+`CERT_WEB_DOMAIN_COMMON_NAME` es opcional; si no se define, se usa el primer valor de `CERT_WEB_DOMAINS`.
+
+### SSL producción con Let's Encrypt
+
+Requisitos:
+
+- El dominio debe resolver públicamente hacia el servidor.
+- El puerto `80` debe estar accesible para el challenge HTTP-01.
+- Usar `SSL_STAGING=true` primero si se quiere probar sin consumir rate limits.
+
+Ejemplo:
+
+```env
+SSL_MODE=prod
+CERT_WEB_DOMAINS=sihsalus.example.org
+CERT_CONTACT_EMAIL=admin@example.org
+SSL_STAGING=false
+```
+
+```bash
+docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl up -d
+```
+
+El contenedor `certbot` crea un certificado temporal para que nginx arranque, valida el challenge HTTP-01, reemplaza el temporal por el certificado de Let's Encrypt y luego renueva cada `CERT_RENEWAL_INTERVAL`.
 
 ### SSL con Keycloak
 
@@ -317,26 +343,33 @@ docker compose \
 
 | Variable | Descripción | Default |
 |----------|-------------|---------|
-| `SSL_MODE` | `dev` (genera una vez y termina) o `prod` (renueva automáticamente) | `dev` |
+| `SSL_MODE` | `dev` para auto-firmado o `prod` para Let's Encrypt | `dev` |
 | `CERT_WEB_DOMAINS` | Todas las direcciones por las que se accederá al servidor, separadas por coma (IPs y/o nombres) | `localhost,127.0.0.1` |
-| `CERT_WEB_DOMAIN_COMMON_NAME` | La dirección principal del servidor (IP o nombre) | `localhost` |
+| `CERT_WEB_DOMAIN_COMMON_NAME` | Dirección principal del servidor; si se omite usa el primer dominio | primer `CERT_WEB_DOMAINS` |
+| `CERT_CONTACT_EMAIL` | Email de contacto para Let's Encrypt | vacío |
+| `SSL_STAGING` | Usa staging de Let's Encrypt para pruebas | `false` |
+| `CERT_PROFILE` | Perfil Let's Encrypt: `classic`, `tlsserver` o `shortlived` | vacío |
 | `CERT_RSA_KEY_SIZE` | Tamaño de la clave RSA y de los parámetros DH generados por certbot | `2048` |
+| `CERT_NGINX_STARTUP_WAIT` | Espera antes de solicitar el certificado real en `prod` | `10` |
+| `CERT_RENEWAL_INTERVAL` | Intervalo del daemon de renovación en `prod` | `12h` |
 
 ### Ejemplo para despliegue en hospital
 
 Si el servidor tiene IP `192.168.10.5` en la red del hospital y los equipos acceden por esa IP:
 
 ```env
-CERT_WEB_DOMAIN_COMMON_NAME=192.168.10.5
+SSL_MODE=dev
 CERT_WEB_DOMAINS=192.168.10.5,localhost,127.0.0.1
 ```
 
 Si el hospital tiene varias VLANs y el servidor tiene más de una IP, incluirlas todas:
 
 ```env
-CERT_WEB_DOMAIN_COMMON_NAME=192.168.10.5
+SSL_MODE=dev
 CERT_WEB_DOMAINS=192.168.10.5,192.168.20.5,172.16.0.5,localhost,127.0.0.1
 ```
+
+Let's Encrypt tambien puede emitir certificados para IP publicas, pero exige el perfil `shortlived`. Si `SSL_MODE=prod` y `CERT_WEB_DOMAINS` contiene una IP, SIH Salus selecciona `CERT_PROFILE=shortlived` automáticamente.
 
 ### Instalar el certificado en los equipos del hospital
 

--- a/certbot/Dockerfile
+++ b/certbot/Dockerfile
@@ -1,29 +1,26 @@
 # syntax=docker/dockerfile:1.3
-FROM alpine:3.19
+FROM certbot/certbot:v4.0.0
 
-# Install OpenSSL and other required tools
 RUN apk --no-cache add \
-    openssl \
     curl \
-    bash \
     tzdata && \
-    # Set timezone to Lima
     cp /usr/share/zoneinfo/America/Lima /etc/localtime && \
     echo "America/Lima" > /etc/timezone
 
-# Create directories
 RUN mkdir -p /certbot/scripts /var/www/certbot/conf /etc/letsencrypt/live
 
-# Copy scripts
 COPY ./scripts /certbot/scripts
 RUN chmod +x /certbot/scripts/entrypoint.sh
 
-# Set environment variables with defaults
 ENV CERT_ROOT_PATH=/etc/letsencrypt \
     CERTBOT_DATA_PATH=/var/www/certbot \
-    CERT_RSA_KEY_SIZE=4096 \
+    CERT_RSA_KEY_SIZE=2048 \
     CERT_TEMP_CERT_DAYS=365 \
-    CERT_RENEWAL_INTERVAL=30d \
+    CERT_NGINX_STARTUP_WAIT=10 \
+    CERT_RENEWAL_INTERVAL=12h \
+    CERT_PROFILE= \
+    CERT_CONTACT_EMAIL= \
+    SSL_STAGING=false \
     SSL_MODE=dev \
     CERT_WEB_DOMAINS=localhost,127.0.0.1 \
     CERT_ORG="Centro de Salud Santa Clotilde" \

--- a/certbot/scripts/entrypoint.sh
+++ b/certbot/scripts/entrypoint.sh
@@ -118,6 +118,8 @@ CERT_FILE="${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}/fullchain.pem"
 KEY_FILE="${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}/privkey.pem"
 RENEWAL_CONF="${CERT_ROOT_PATH}/renewal/${CERT_WEB_DOMAIN_COMMON_NAME}.conf"
 
+ensure_tls_params
+
 if [ -f "${CERT_FILE}" ] && [ -f "${KEY_FILE}" ]; then
     log_info "Certificates already exist for ${CERT_WEB_DOMAIN_COMMON_NAME}"
     if [ "${SSL_MODE}" = "prod" ]; then
@@ -134,7 +136,6 @@ if [ -f "${CERT_FILE}" ] && [ -f "${KEY_FILE}" ]; then
     fi
 fi
 
-ensure_tls_params
 mkdir -p "${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}"
 
 if [ "${SSL_MODE}" = "dev" ]; then
@@ -255,6 +256,7 @@ certbot certonly --webroot -w "${CERTBOT_DATA_PATH}" \
     ${EMAIL_ARG} \
     ${DOMAIN_ARGS} \
     ${PROFILE_ARG} \
+    --cert-name "${CERT_WEB_DOMAIN_COMMON_NAME}" \
     --rsa-key-size "${CERT_RSA_KEY_SIZE}" \
     --agree-tos \
     --no-eff-email

--- a/certbot/scripts/entrypoint.sh
+++ b/certbot/scripts/entrypoint.sh
@@ -7,11 +7,12 @@
 #	Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
 #	graphic logo is a trademark of OpenMRS Inc.
 #
-#   Adapted for sihsalus - Self-signed certificate management for internal hospital networks
+# Adapted for SIH Salus. Development mode creates self-signed certificates for
+# internal hospital networks; production mode obtains and renews Let's Encrypt
+# certificates using the HTTP-01 webroot challenge served by the gateway.
 
 set -e
 
-# Logging helpers
 log_info() {
     echo "[$(date +'%Y-%m-%d %H:%M:%S')] [INFO] $*"
 }
@@ -24,18 +25,27 @@ log_error() {
     echo "[$(date +'%Y-%m-%d %H:%M:%S')] [ERROR] $*" >&2
 }
 
-# Configuration with enhanced defaults
 SSL_MODE=${SSL_MODE:-dev}
+SSL_STAGING=${SSL_STAGING:-false}
+CERT_ROOT_PATH=${CERT_ROOT_PATH:-/etc/letsencrypt}
+CERTBOT_DATA_PATH=${CERTBOT_DATA_PATH:-/var/www/certbot}
+CERT_RSA_KEY_SIZE=${CERT_RSA_KEY_SIZE:-2048}
 CERT_TEMP_CERT_DAYS=${CERT_TEMP_CERT_DAYS:-365}
-CERT_RENEWAL_INTERVAL=${CERT_RENEWAL_INTERVAL:-30d}
-CERT_RSA_KEY_SIZE=${CERT_RSA_KEY_SIZE:-4096}
+CERT_NGINX_STARTUP_WAIT=${CERT_NGINX_STARTUP_WAIT:-10}
+CERT_RENEWAL_INTERVAL=${CERT_RENEWAL_INTERVAL:-12h}
+CERT_PROFILE=${CERT_PROFILE:-}
+CERT_CONTACT_EMAIL=${CERT_CONTACT_EMAIL:-}
 CERT_ORG=${CERT_ORG:-"Centro de Salud Santa Clotilde"}
 CERT_OU=${CERT_OU:-"sihsalus"}
 CERT_COUNTRY=${CERT_COUNTRY:-"PE"}
 CERT_STATE=${CERT_STATE:-"Loreto"}
 CERT_LOCALITY=${CERT_LOCALITY:-"Maynas"}
 
-# Parse domain list
+if [ -z "${CERT_WEB_DOMAINS:-}" ]; then
+    log_error "CERT_WEB_DOMAINS is required"
+    exit 1
+fi
+
 OLD_IFS="$IFS"
 IFS=","
 set -- ${CERT_WEB_DOMAINS}
@@ -44,119 +54,111 @@ IFS=${OLD_IFS}
 FIRST_DOMAIN="$1"
 CERT_WEB_DOMAIN_COMMON_NAME="${CERT_WEB_DOMAIN_COMMON_NAME:-$FIRST_DOMAIN}"
 
-log_info "=== sihsalus Certificate Manager ==="
-log_info "SSL Mode: ${SSL_MODE}"
-log_info "Primary domain: ${CERT_WEB_DOMAIN_COMMON_NAME}"
-log_info "RSA Key Size: ${CERT_RSA_KEY_SIZE} bits"
-log_info "Certificate validity: ${CERT_TEMP_CERT_DAYS} days"
-
-# Check if certificates already exist
-if [ -f "${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}/fullchain.pem" ]; then
-    log_info "Certificates already exist for ${CERT_WEB_DOMAIN_COMMON_NAME}"
-
-    # Check certificate expiration
-    CERT_FILE="${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}/fullchain.pem"
-    EXPIRY_DATE=$(openssl x509 -enddate -noout -in "${CERT_FILE}" | cut -d= -f2)
-    EXPIRY_EPOCH=$(date -d "${EXPIRY_DATE}" +%s)
-    CURRENT_EPOCH=$(date +%s)
-    DAYS_UNTIL_EXPIRY=$(( (EXPIRY_EPOCH - CURRENT_EPOCH) / 86400 ))
-
-    log_info "Certificate expires in ${DAYS_UNTIL_EXPIRY} days"
-
-    # Renew if less than 30 days remaining
-    if [ "${DAYS_UNTIL_EXPIRY}" -lt 30 ]; then
-        log_warn "Certificate expiring soon, regenerating..."
-        rm -rf "${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}"
-    else
-        if [ "${SSL_MODE}" = "prod" ]; then
-            log_info "Starting certificate renewal daemon..."
-            trap 'log_info "Received SIGTERM, shutting down..."; exit 0' TERM
-            while :; do
-                # Check expiration and renew if needed
-                EXPIRY_DATE=$(openssl x509 -enddate -noout -in "${CERT_FILE}" | cut -d= -f2)
-                EXPIRY_EPOCH=$(date -d "${EXPIRY_DATE}" +%s)
-                CURRENT_EPOCH=$(date +%s)
-                DAYS_UNTIL_EXPIRY=$(( (EXPIRY_EPOCH - CURRENT_EPOCH) / 86400 ))
-
-                if [ "${DAYS_UNTIL_EXPIRY}" -lt 30 ]; then
-                    log_info "Renewing certificate..."
-                    rm -rf "${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}"
-                    # Script will restart and regenerate
-                    exec "$0" "$@"
-                else
-                    log_info "Certificate valid for ${DAYS_UNTIL_EXPIRY} more days"
-                fi
-
-                sleep "${CERT_RENEWAL_INTERVAL}" &
-                wait $!
-            done
-        else
-            log_info "Dev mode: certificates exist and valid. Exiting."
-            exit 0
-        fi
-    fi
-fi
-
-# Initial certificate setup
-log_info "Setting up initial certificates..."
-log_info "=== Self-Signed Certificate Mode ==="
-log_info "For internal hospital networks and development"
-
-mkdir -p "${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}"
-mkdir -p "${CERTBOT_DATA_PATH}/conf"
-
-# Create enhanced SSL config files
-if [ ! -e "${CERTBOT_DATA_PATH}/conf/options-ssl-nginx.conf" ]; then
-    log_info "Creating enhanced SSL configuration..."
-    cat > "${CERTBOT_DATA_PATH}/conf/options-ssl-nginx.conf" <<'EOF'
-# Enhanced SSL configuration for self-signed certificates
-# Based on Mozilla Intermediate configuration
-ssl_session_cache shared:SSL:10m;
-ssl_session_timeout 1440m;
-ssl_session_tickets off;
-
-# Protocols - Only TLS 1.2 and 1.3
-ssl_protocols TLSv1.2 TLSv1.3;
-ssl_prefer_server_ciphers off;
-
-# Modern cipher suite
-ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
-
-# OCSP Stapling - disabled for self-signed
-# ssl_stapling on;
-# ssl_stapling_verify on;
-EOF
-fi
-
-# Create strong DH parameters
-if [ ! -e "${CERTBOT_DATA_PATH}/conf/ssl-dhparams.pem" ]; then
-    log_info "Creating strong DH parameters (${CERT_RSA_KEY_SIZE} bits)..."
-    log_info "This may take several minutes..."
-    openssl dhparam -out "${CERTBOT_DATA_PATH}/conf/ssl-dhparams.pem" ${CERT_RSA_KEY_SIZE}
-    log_info "DH parameters created successfully!"
-fi
-
-# Build subject alternative names
-DNS_NUM=0
-IP_NUM=0
-SUBJECT_ALTERNATE_NAMES=""
-
-for WEB_DOMAIN in "$@"; do
-    if expr "X$WEB_DOMAIN" : 'X[.0-9]+' >/dev/null; then
-        SUBJECT_ALTERNATE_NAMES="${SUBJECT_ALTERNATE_NAMES}IP.${IP_NUM} = ${WEB_DOMAIN}
-"
-        IP_NUM=$((IP_NUM + 1))
-        log_info "  - IP: ${WEB_DOMAIN}"
-    else
-        SUBJECT_ALTERNATE_NAMES="${SUBJECT_ALTERNATE_NAMES}DNS.${DNS_NUM} = ${WEB_DOMAIN}
-"
-        DNS_NUM=$((DNS_NUM + 1))
-        log_info "  - Domain: ${WEB_DOMAIN}"
+HAS_IP_ADDRESS=false
+for DOMAIN in "$@"; do
+    if echo "$DOMAIN" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' || echo "$DOMAIN" | grep -q ':'; then
+        HAS_IP_ADDRESS=true
+        break
     fi
 done
 
-# Create enhanced SSL config with extended key usage
-cat > /tmp/sslconfig.conf <<EOF
+if [ "$HAS_IP_ADDRESS" = "true" ] && [ "${SSL_MODE}" = "prod" ]; then
+    if [ -z "${CERT_PROFILE}" ]; then
+        log_info "IP address detected. Selecting Let's Encrypt 'shortlived' profile."
+        CERT_PROFILE="shortlived"
+    elif [ "${CERT_PROFILE}" != "shortlived" ]; then
+        log_error "IP address detected but CERT_PROFILE is '${CERT_PROFILE}'."
+        log_error "Let's Encrypt requires IP address certificates to use the 'shortlived' profile."
+        exit 1
+    fi
+fi
+
+log_info "=== SIH Salus Certificate Manager ==="
+log_info "SSL mode: ${SSL_MODE}"
+log_info "Primary domain: ${CERT_WEB_DOMAIN_COMMON_NAME}"
+log_info "RSA key size: ${CERT_RSA_KEY_SIZE} bits"
+if [ -n "${CERT_PROFILE}" ]; then
+    log_info "Certificate profile: ${CERT_PROFILE}"
+fi
+
+ensure_tls_params() {
+    mkdir -p "${CERTBOT_DATA_PATH}/conf"
+
+    if [ ! -e "${CERTBOT_DATA_PATH}/conf/options-ssl-nginx.conf" ]; then
+        log_info "Creating nginx TLS options"
+        cat > "${CERTBOT_DATA_PATH}/conf/options-ssl-nginx.conf" <<'EOF'
+ssl_session_cache shared:SSL:10m;
+ssl_session_timeout 1440m;
+ssl_session_tickets off;
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_prefer_server_ciphers off;
+ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+EOF
+    fi
+
+    if [ ! -e "${CERTBOT_DATA_PATH}/conf/ssl-dhparams.pem" ]; then
+        log_info "Creating DH parameters (${CERT_RSA_KEY_SIZE} bits)"
+        openssl dhparam -out "${CERTBOT_DATA_PATH}/conf/ssl-dhparams.pem" "${CERT_RSA_KEY_SIZE}"
+    fi
+}
+
+start_renewal_daemon() {
+    log_info "Starting Let's Encrypt renewal daemon"
+    log_info "Renewal interval: ${CERT_RENEWAL_INTERVAL}"
+    trap 'log_info "Received SIGTERM, shutting down"; exit 0' TERM
+    while :; do
+        certbot renew --webroot -w "${CERTBOT_DATA_PATH}" \
+            --deploy-hook "touch ${CERTBOT_DATA_PATH}/.reload-nginx" || true
+        sleep "${CERT_RENEWAL_INTERVAL}" &
+        wait $!
+    done
+}
+
+CERT_FILE="${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}/fullchain.pem"
+KEY_FILE="${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}/privkey.pem"
+RENEWAL_CONF="${CERT_ROOT_PATH}/renewal/${CERT_WEB_DOMAIN_COMMON_NAME}.conf"
+
+if [ -f "${CERT_FILE}" ] && [ -f "${KEY_FILE}" ]; then
+    log_info "Certificates already exist for ${CERT_WEB_DOMAIN_COMMON_NAME}"
+    if [ "${SSL_MODE}" = "prod" ]; then
+        if [ -f "${RENEWAL_CONF}" ]; then
+            start_renewal_daemon
+        fi
+        log_warn "Existing certificate has no certbot renewal config; replacing it with a Let's Encrypt certificate"
+        rm -rf "${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}"
+        rm -rf "${CERT_ROOT_PATH}/archive/${CERT_WEB_DOMAIN_COMMON_NAME}"
+        rm -f "${RENEWAL_CONF}"
+    else
+        log_info "Dev mode: certificates exist, nothing to do"
+        exit 0
+    fi
+fi
+
+ensure_tls_params
+mkdir -p "${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}"
+
+if [ "${SSL_MODE}" = "dev" ]; then
+    log_info "Creating self-signed certificate for internal/development use"
+
+    DNS_NUM=0
+    IP_NUM=0
+    SUBJECT_ALTERNATE_NAMES=""
+
+    for WEB_DOMAIN in "$@"; do
+        if echo "$WEB_DOMAIN" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' || echo "$WEB_DOMAIN" | grep -q ':'; then
+            SUBJECT_ALTERNATE_NAMES="${SUBJECT_ALTERNATE_NAMES}IP.${IP_NUM} = ${WEB_DOMAIN}
+"
+            IP_NUM=$((IP_NUM + 1))
+            log_info "SAN IP: ${WEB_DOMAIN}"
+        else
+            SUBJECT_ALTERNATE_NAMES="${SUBJECT_ALTERNATE_NAMES}DNS.${DNS_NUM} = ${WEB_DOMAIN}
+"
+            DNS_NUM=$((DNS_NUM + 1))
+            log_info "SAN DNS: ${WEB_DOMAIN}"
+        fi
+    done
+
+    cat > /tmp/sslconfig.conf <<EOF
 [req]
 distinguished_name = req_distinguished_name
 x509_extensions = v3_ca
@@ -180,67 +182,84 @@ extendedKeyUsage = serverAuth
 ${SUBJECT_ALTERNATE_NAMES}
 EOF
 
-log_info "Creating self-signed certificate for ${CERT_WEB_DOMAIN_COMMON_NAME}..."
-log_info "Organization: ${CERT_ORG}"
-log_info "Organizational Unit: ${CERT_OU}"
-log_info "Subject Alternative Names:"
+    openssl req -x509 -nodes -newkey "rsa:${CERT_RSA_KEY_SIZE}" -days "${CERT_TEMP_CERT_DAYS}" \
+        -keyout "${KEY_FILE}" \
+        -out "${CERT_FILE}" \
+        -config /tmp/sslconfig.conf
 
-openssl req -x509 -nodes -newkey "rsa:${CERT_RSA_KEY_SIZE}" -days "${CERT_TEMP_CERT_DAYS}" \
-    -keyout "${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}/privkey.pem" \
-    -out "${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}/fullchain.pem" \
-    -config /tmp/sslconfig.conf
+    chmod 600 "${KEY_FILE}"
+    chmod 644 "${CERT_FILE}"
 
-# Set proper permissions
-chmod 600 "${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}/privkey.pem"
-chmod 644 "${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}/fullchain.pem"
-
-log_info "✓ Self-signed certificates created successfully!"
-log_info "✓ Certificate fingerprint:"
-openssl x509 -noout -fingerprint -sha256 -in "${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}/fullchain.pem"
-
-log_info ""
-log_info "IMPORTANT: Certificate Installation Instructions"
-log_info "================================================"
-log_info "1. Download the certificate from: ${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}/fullchain.pem"
-log_info "2. Install it in your browser/system trust store"
-log_info "3. For Windows: Import to 'Trusted Root Certification Authorities'"
-log_info "4. For Linux: Copy to /usr/local/share/ca-certificates/ and run update-ca-certificates"
-log_info "5. For macOS: Import to Keychain Access and set to 'Always Trust'"
-log_info ""
-
-# Signal nginx to reload with the certificate
-if [ -d "${CERTBOT_DATA_PATH}" ]; then
-    log_info "Signaling nginx to reload configuration..."
+    log_info "Self-signed certificate created"
+    openssl x509 -noout -fingerprint -sha256 -in "${CERT_FILE}"
     touch "${CERTBOT_DATA_PATH}/.reload-nginx"
+    exit 0
 fi
 
-# Start renewal daemon if in production mode
-if [ "${SSL_MODE}" = "prod" ]; then
-    log_info "Starting certificate renewal daemon..."
-    log_info "Checking for renewal every ${CERT_RENEWAL_INTERVAL}"
-    trap 'log_info "Received SIGTERM, shutting down..."; exit 0' TERM
-    while :; do
-        sleep "${CERT_RENEWAL_INTERVAL}" &
-        wait $!
+if [ "${SSL_MODE}" != "prod" ]; then
+    log_error "Unsupported SSL_MODE '${SSL_MODE}'. Use 'dev' or 'prod'."
+    exit 1
+fi
 
-        # Check expiration
-        CERT_FILE="${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}/fullchain.pem"
-        if [ -f "${CERT_FILE}" ]; then
-            EXPIRY_DATE=$(openssl x509 -enddate -noout -in "${CERT_FILE}" | cut -d= -f2)
-            EXPIRY_EPOCH=$(date -d "${EXPIRY_DATE}" +%s)
-            CURRENT_EPOCH=$(date +%s)
-            DAYS_UNTIL_EXPIRY=$(( (EXPIRY_EPOCH - CURRENT_EPOCH) / 86400 ))
+log_info "Setting up Let's Encrypt certificate"
 
-            log_info "Certificate check: ${DAYS_UNTIL_EXPIRY} days until expiry"
+log_info "Creating temporary certificate so nginx can start"
+openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
+    -keyout "${KEY_FILE}" \
+    -out "${CERT_FILE}" \
+    -subj "/CN=${CERT_WEB_DOMAIN_COMMON_NAME}"
 
-            if [ "${DAYS_UNTIL_EXPIRY}" -lt 30 ]; then
-                log_info "Certificate expiring soon, regenerating..."
-                rm -rf "${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}"
-                # Script will restart and regenerate
-                exec "$0" "$@"
-            fi
-        fi
-    done
+log_info "Waiting ${CERT_NGINX_STARTUP_WAIT}s for nginx to start"
+sleep "${CERT_NGINX_STARTUP_WAIT}"
+
+mkdir -p "${CERTBOT_DATA_PATH}/.well-known/acme-challenge"
+echo "ok" > "${CERTBOT_DATA_PATH}/.well-known/acme-challenge/index.html"
+
+until curl -fsS --max-time 5 http://gateway/.well-known/acme-challenge/ >/dev/null 2>&1; do
+    log_info "Waiting for nginx gateway to serve ACME challenge files"
+    sleep 5
+done
+
+log_info "Gateway is ready. Requesting Let's Encrypt certificate."
+
+rm -rf "${CERT_ROOT_PATH}/live/${CERT_WEB_DOMAIN_COMMON_NAME}"
+rm -rf "${CERT_ROOT_PATH}/archive/${CERT_WEB_DOMAIN_COMMON_NAME}"
+rm -f "${CERT_ROOT_PATH}/renewal/${CERT_WEB_DOMAIN_COMMON_NAME}.conf"
+
+DOMAIN_ARGS=""
+for CERT_WEB_DOMAIN in "$@"; do
+    DOMAIN_ARGS="${DOMAIN_ARGS} -d ${CERT_WEB_DOMAIN}"
+done
+
+if [ -n "${CERT_CONTACT_EMAIL}" ]; then
+    EMAIL_ARG="--email ${CERT_CONTACT_EMAIL}"
 else
-    log_info "Dev mode: Certificate generated. Exiting."
+    log_warn "CERT_CONTACT_EMAIL is not set. Registering without email is not recommended."
+    EMAIL_ARG="--register-unsafely-without-email"
 fi
+
+STAGING_ARG=""
+if [ "${SSL_STAGING}" = "true" ]; then
+    log_info "Using Let's Encrypt staging environment"
+    STAGING_ARG="--staging"
+fi
+
+PROFILE_ARG=""
+if [ -n "${CERT_PROFILE}" ]; then
+    log_info "Requesting certificate profile: ${CERT_PROFILE}"
+    PROFILE_ARG="--preferred-profile ${CERT_PROFILE}"
+fi
+
+certbot certonly --webroot -w "${CERTBOT_DATA_PATH}" \
+    ${STAGING_ARG} \
+    ${EMAIL_ARG} \
+    ${DOMAIN_ARGS} \
+    ${PROFILE_ARG} \
+    --rsa-key-size "${CERT_RSA_KEY_SIZE}" \
+    --agree-tos \
+    --no-eff-email
+
+log_info "Let's Encrypt certificate obtained"
+touch "${CERTBOT_DATA_PATH}/.reload-nginx"
+
+start_renewal_daemon

--- a/compose/README.md
+++ b/compose/README.md
@@ -306,7 +306,7 @@ Certificados y configuración HTTPS (Let's Encrypt o auto-firmados).
 docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl up -d
 
 # Production (Let's Encrypt)
-export SSL_MODE=prod CERT_WEB_DOMAINS=yourdomain.com
+export SSL_MODE=prod CERT_WEB_DOMAINS=yourdomain.com CERT_CONTACT_EMAIL=admin@yourdomain.com
 docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl up -d
 ```
 
@@ -317,10 +317,17 @@ docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl up -d
 ```env
 SSL_MODE=dev                                                # dev o prod
 CERT_WEB_DOMAINS=localhost,127.0.0.1,192.168.0.200        # Dominios (comma-separated)
-CERT_WEB_DOMAIN_COMMON_NAME=localhost                      # CN del certificado
+CERT_WEB_DOMAIN_COMMON_NAME=                               # Opcional; por defecto usa el primer dominio
+CERT_CONTACT_EMAIL=                                        # Recomendado con SSL_MODE=prod
+SSL_STAGING=false                                          # true para probar Let's Encrypt staging
+CERT_PROFILE=                                              # classic, tlsserver o shortlived
 CERT_RSA_KEY_SIZE=2048                                     # Tamaño clave RSA y DH params
 CERT_TEMP_CERT_DAYS=365                                    # Validez certs auto-firmados
+CERT_NGINX_STARTUP_WAIT=10                                 # Espera antes de solicitar cert real
+CERT_RENEWAL_INTERVAL=12h                                  # Intervalo de renovacion certbot
 ```
+
+En `SSL_MODE=prod`, certbot crea un certificado temporal para que nginx pueda arrancar, sirve el challenge HTTP-01 desde `/.well-known/acme-challenge/`, solicita el certificado real de Let's Encrypt y luego renueva automáticamente. Para pruebas, usar `SSL_STAGING=true`.
 
 **Nota**: Sobreescribe el servicio `gateway` para agregar HTTPS (puerto 443).
 

--- a/compose/ssl.yml
+++ b/compose/ssl.yml
@@ -1,7 +1,9 @@
 # SSL/HTTPS Configuration (standalone override)
 # Usage: docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl up -d
 #
-# This file overrides the gateway to add SSL support and adds the certbot service.
+# This file overrides the gateway to add HTTPS and adds the certbot service.
+# SSL_MODE=dev creates self-signed certificates.
+# SSL_MODE=prod obtains and renews Let's Encrypt certificates via HTTP-01.
 # It is NOT included via `include:` because it modifies the gateway service.
 
 services:
@@ -15,10 +17,14 @@ services:
     environment:
       SSL_MODE: ${SSL_MODE:-dev}
       CERT_WEB_DOMAINS: ${CERT_WEB_DOMAINS:-localhost,127.0.0.1,192.168.0.200,sihsalus.hsc,openmrs.sihsalus.hsc}
-      CERT_WEB_DOMAIN_COMMON_NAME: ${CERT_WEB_DOMAIN_COMMON_NAME:-localhost}
+      CERT_WEB_DOMAIN_COMMON_NAME: ${CERT_WEB_DOMAIN_COMMON_NAME:-}
+      CERT_CONTACT_EMAIL: ${CERT_CONTACT_EMAIL:-}
+      SSL_STAGING: ${SSL_STAGING:-false}
+      CERT_PROFILE: ${CERT_PROFILE:-}
       CERT_RSA_KEY_SIZE: ${CERT_RSA_KEY_SIZE:-2048}
       CERT_TEMP_CERT_DAYS: ${CERT_TEMP_CERT_DAYS:-365}
-      CERT_RENEWAL_INTERVAL: ${CERT_RENEWAL_INTERVAL:-30d}
+      CERT_NGINX_STARTUP_WAIT: ${CERT_NGINX_STARTUP_WAIT:-10}
+      CERT_RENEWAL_INTERVAL: ${CERT_RENEWAL_INTERVAL:-12h}
       CERT_ORG: ${CERT_ORG:-Centro de Salud Santa Clotilde}
       CERT_OU: ${CERT_OU:-sihsalus}
       CERT_COUNTRY: ${CERT_COUNTRY:-PE}
@@ -38,7 +44,8 @@ services:
     ports:
       - "${GATEWAY_HTTPS_PORT:-443}:443"
     environment:
-      CERT_WEB_DOMAIN_COMMON_NAME: ${CERT_WEB_DOMAIN_COMMON_NAME:-localhost}
+      CERT_WEB_DOMAINS: ${CERT_WEB_DOMAINS:-localhost,127.0.0.1,192.168.0.200,sihsalus.hsc,openmrs.sihsalus.hsc}
+      CERT_WEB_DOMAIN_COMMON_NAME: ${CERT_WEB_DOMAIN_COMMON_NAME:-}
       FRAME_ANCESTORS: ${FRAME_ANCESTORS:-https://dyaku.minsa.gob.pe/fhir}
     healthcheck:
       # El entrypoint del gateway espera a que certbot genere los certificados


### PR DESCRIPTION
## Summary
- switch certbot image to the official certbot runtime so production mode can request real Let's Encrypt certificates
- keep SSL_MODE=dev self-signed certificate generation for internal/offline hospital networks
- add SSL_MODE=prod HTTP-01 flow: temporary bootstrap certificate, gateway challenge readiness check, real certificate request, nginx reload signal, and renewal daemon
- support SSL_STAGING, CERT_CONTACT_EMAIL, CERT_PROFILE, CERT_NGINX_STARTUP_WAIT, and automatic shortlived profile for IP-address certificates
- pass CERT_WEB_DOMAINS to the gateway so CERT_WEB_DOMAIN_COMMON_NAME can be derived consistently
- document dev self-signed vs production Let's Encrypt setup

## Validation
- sh -n certbot/scripts/entrypoint.sh
- docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl config
- git diff --check
- ran certbot/scripts/entrypoint.sh in SSL_MODE=dev with temporary CERT_ROOT_PATH/CERTBOT_DATA_PATH and confirmed fullchain.pem, privkey.pem, options-ssl-nginx.conf, and ssl-dhparams.pem were created

## Not run
- docker build for certbot image: local Docker daemon is not running on this machine (/var/run/docker.sock missing)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->