### PR TITLE
Add security and deployment evidence

### DIFF
--- a/.github/workflows/validate-compose.yml
+++ b/.github/workflows/validate-compose.yml
@@ -37,22 +37,66 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Prepare evidence directory
+        run: mkdir -p compose-validation
+
       - name: Validate core stack
-        run: docker compose config --quiet
+        run: |
+          docker compose config --quiet
+          docker compose config > compose-validation/core.yml
 
       - name: Validate optional profiles
         run: |
-          docker compose --profile fua config --quiet
-          docker compose --profile hapi config --quiet
-          docker compose --profile imaging config --quiet
-          docker compose --profile indicadores config --quiet
-          docker compose --profile keycloak config --quiet
-          docker compose --profile monitoring --profile logs config --quiet
-          docker compose --profile replica config --quiet
-          docker compose --profile keycloak config --quiet
+          set -euo pipefail
+
+          validate() {
+            name="$1"
+            shift
+            docker compose "$@" config --quiet
+            docker compose "$@" config > "compose-validation/${name}.yml"
+          }
+
+          validate fua --profile fua
+          validate hapi --profile hapi
+          validate imaging --profile imaging
+          validate indicadores --profile indicadores
+          validate keycloak --profile keycloak
+          validate monitoring-logs --profile monitoring --profile logs
+          validate replica --profile replica
 
       - name: Validate standalone overrides
         run: |
-          docker compose -f docker-compose.yml -f compose/status.yml --profile status config --quiet
-          docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl config --quiet
-          docker compose -f docker-compose.yml -f compose/ssl.yml --profile keycloak --profile ssl config --quiet
+          set -euo pipefail
+
+          validate_override() {
+            name="$1"
+            shift
+            docker compose "$@" config --quiet
+            docker compose "$@" config > "compose-validation/${name}.yml"
+          }
+
+          validate_override status -f docker-compose.yml -f compose/status.yml --profile status
+          validate_override ssl -f docker-compose.yml -f compose/ssl.yml --profile ssl
+          validate_override keycloak-ssl -f docker-compose.yml -f compose/ssl.yml --profile keycloak --profile ssl
+
+      - name: Write validation summary
+        if: always()
+        run: |
+          {
+            echo "## Compose validation evidence"
+            echo ""
+            echo "| Target | Evidence file |"
+            echo "| --- | --- |"
+            for file in compose-validation/*.yml; do
+              name="$(basename "$file" .yml)"
+              echo "| ${name} | ${file} |"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload compose validation evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compose-validation
+          path: compose-validation/
+          if-no-files-found: error

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported scope
+
+Security reports are accepted for the current `main` branch and the currently deployed SIHSalus environment.
+
+In scope:
+- Docker Compose configuration, profiles and deployment scripts.
+- Gateway, HTTPS, CSP and reverse proxy configuration.
+- OpenMRS backend distribution configuration.
+- Keycloak/OAuth2 integration.
+- CI workflows and supply-chain configuration.
+- Handling of secrets, credentials, tokens and sensitive operational data.
+
+Out of scope:
+- Social engineering, phishing or physical attacks.
+- Denial-of-service testing without prior authorization.
+- Vulnerabilities in upstream projects unless SIHSalus configuration makes them exploitable.
+- Public disclosure before maintainers have had time to triage and mitigate.
+
+## Reporting a vulnerability
+
+Use GitHub private vulnerability reporting or Security Advisories when available.
+
+If private reporting is not available, contact a maintainer directly and avoid public issues for sensitive reports.
+
+Do not include real patient data, production credentials, tokens, private keys or screenshots containing personal data.
+
+## Response targets
+
+These targets are operational goals, not legal guarantees.
+
+| Severity | Acknowledge | Triage target | Mitigation target |
+| --- | ---: | ---: | ---: |
+| Critical | 1 business day | 3 calendar days | 7 calendar days |
+| High | 2 business days | 7 calendar days | 14 calendar days |
+| Medium | 3 business days | 14 calendar days | 30 calendar days |
+| Low | 5 business days | 30 calendar days | Best effort |
+
+## Coordinated disclosure
+
+Please give maintainers a reasonable opportunity to investigate and mitigate before public disclosure.
+
+Maintainers will credit reporters when appropriate and requested.

--- a/docs/operations/deploy-checklist.md
+++ b/docs/operations/deploy-checklist.md
@@ -1,0 +1,64 @@
+# Checklist de despliegue SIHSalus
+
+Usar este checklist para cambios en `main`, despliegues de `qlty`, `staging` o producción.
+
+## Antes del despliegue
+
+- PR aprobado y mergeado.
+- CI requerido en verde.
+- Versiones a desplegar identificadas: backend, frontend, content package y perfiles habilitados.
+- Backup reciente confirmado.
+- Ruta de rollback definida.
+- Variables y secretos requeridos confirmados sin exponer valores.
+- Si el entorno usa HTTPS, todos los comandos Compose incluyen `-f compose/ssl.yml --profile ssl`.
+
+## Ejecución
+
+```bash
+git pull --ff-only
+docker compose config --quiet
+docker compose ps
+```
+
+Para entornos HTTPS:
+
+```bash
+docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl config --quiet
+docker compose -f docker-compose.yml -f compose/ssl.yml --profile ssl ps
+```
+
+Registrar:
+
+| Campo | Valor |
+| --- | --- |
+| Fecha/hora | |
+| Responsable | |
+| Ambiente | |
+| Commit desplegado | |
+| Backend tag | |
+| Frontend tag | |
+| Content package | |
+| Perfiles activos | |
+| Backup usado como referencia | |
+| Plan de rollback | |
+
+## Smoke test posterior
+
+- `GET /health` responde correctamente.
+- `GET /startup` responde correctamente.
+- `GET /ready` responde correctamente cuando OpenMRS termina bootstrap.
+- `/openmrs/spa/home` carga en navegador.
+- Login funciona.
+- Roles principales pueden acceder a sus superficies esperadas.
+- Si aplica, Keycloak redirige a `/openmrs/spa/home`.
+- Si aplica, FUA responde bajo su ruta de gateway.
+- Si aplica, indicadores responde bajo `/openmrs/services/reportes-sql`.
+- Si aplica, imaging/OHIF no muestra errores de gateway/CSP.
+- Logs de `gateway` y `backend` sin errores nuevos críticos.
+
+## Cierre
+
+- Resultado documentado.
+- Incidentes o degradaciones registradas.
+- Rollback ejecutado o descartado explícitamente.
+- Evidencia de CI y smoke test adjuntada al cambio o bitácora operativa.

--- a/docs/operations/profiles.md
+++ b/docs/operations/profiles.md
@@ -4,13 +4,13 @@ Este documento define los perfiles operativos para despliegues de SIH Salus en e
 
 ## Principios
 
-- El perfil por defecto debe permitir atencion clinica local sin internet.
+- El perfil por defecto debe permitir atención clínica local sin internet.
 - Todo servicio habilitado debe tener un responsable operativo claro.
 - Los puestos remotos deben usar la menor cantidad posible de servicios.
 - Las herramientas técnicas no deben exponerse al personal clínico o administrativo.
 - Los paneles de estado no deben mostrar datos personales, datos de salud, tokens ni secretos.
 - El semáforo local debe considerarse un control parcial de disponibilidad, no una certificación de cumplimiento normativo.
-- Las acciones administrativas deben quedar registradas cuando afecten continuidad, seguridad, backup o restauracion.
+- Las acciones administrativas deben quedar registradas cuando afecten continuidad, seguridad, backup o restauración.
 
 ## Puesto remoto
 
@@ -34,7 +34,7 @@ Servicios deshabilitados por defecto:
 - `logs`
 - `portainer` (instalado bare metal)
 
-Requisitos minimos:
+Requisitos mínimos:
 
 - 4 CPU
 - 8 GB RAM
@@ -45,25 +45,25 @@ Requisitos minimos:
 Puertos expuestos:
 
 - `80` o `443` para acceso local
-- Ningun puerto tecnico expuesto a la red por defecto
+- Ningún puerto técnico expuesto a la red por defecto
 
-Politica operativa:
+Política operativa:
 
 - Debe poder atender pacientes sin internet.
 - Debe mostrar estado en `/admin/local`.
 - Debe ejecutar backup local diario.
 - Debe permitir backup externo semanal.
-- Debe mantener instrucciones impresas de recuperacion.
+- Debe mantener instrucciones impresas de recuperación.
 
 ## Centro de salud
 
-Perfil para establecimientos con mayor capacidad operativa, mas usuarios y posibilidad de servicios complementarios.
+Perfil para establecimientos con mayor capacidad operativa, más usuarios y posibilidad de servicios complementarios.
 
 Servicios habilitados:
 
 - Todo lo del perfil `puesto remoto`
-- `keycloak` opcional si hay gestion formal de usuarios
-- `imaging` solo si existe flujo real de imagenes medicas
+- `keycloak` opcional si hay gestión formal de usuarios
+- `imaging` solo si existe flujo real de imágenes médicas
 
 Servicios deshabilitados por defecto:
 
@@ -72,7 +72,7 @@ Servicios deshabilitados por defecto:
 - `logs`
 - `portainer`
 
-Requisitos minimos:
+Requisitos mínimos:
 
 - 4 a 8 CPU
 - 16 GB RAM
@@ -80,15 +80,15 @@ Requisitos minimos:
 - UPS recomendado
 - Backup externo obligatorio
 
-Politica operativa:
+Política operativa:
 
-- Keycloak solo debe habilitarse si existe procedimiento local de recuperacion de usuarios.
+- Keycloak solo debe habilitarse si existe procedimiento local de recuperación de usuarios.
 - Imaging solo debe habilitarse si hay responsable de almacenamiento y retención DICOM.
-- El panel local debe indicar si el sistema puede atender pacientes y si el ultimo backup es valido.
+- El panel local debe indicar si el sistema puede atender pacientes y si el último backup es válido.
 
 ## Cabecera de microred
 
-Perfil para nodos con capacidad de consolidacion, soporte y monitoreo de varios establecimientos.
+Perfil para nodos con capacidad de consolidación, soporte y monitoreo de varios establecimientos.
 
 Servicios habilitados:
 
@@ -101,26 +101,26 @@ Servicios habilitados:
 
 Servicios restringidos:
 
-- `portainer` solo para soporte tecnico autorizado
+- `portainer` solo para soporte técnico autorizado
 
-Requisitos minimos:
+Requisitos mínimos:
 
 - 8 CPU
 - 32 GB RAM
-- 1 TB SSD o mas segun carga
+- 1 TB SSD o más según carga
 - UPS obligatorio
-- Politica de backup externo y restore probado
+- Política de backup externo y réplica probado
 
-Politica operativa:
+Política operativa:
 
-- Debe consolidar paquetes de sincronizacion de puestos remotos.
-- Debe centralizar monitoreo tecnico.
-- Debe mantener evidencia de backups, restauraciones y actualizaciones.
+- Debe consolidar paquetes de sincronización de puestos remotos.
+- Debe centralizar monitoreo técnico.
+- Debe mantener evidencia de backups y actualizaciones.
 - Debe evitar exponer herramientas administrativas fuera de redes de soporte.
 
 ## Brigada
 
-Perfil portatil para campanas o atencion itinerante.
+Perfil portátil para brigadas o atención itinerante.
 
 Servicios habilitados:
 
@@ -141,61 +141,61 @@ Servicios deshabilitados por defecto:
 - `logs`
 - `portainer`
 
-Requisitos minimos:
+Requisitos mínimos:
 
 - Laptop o mini PC
 - 8 GB RAM
 - 250 GB SSD
-- Bateria o UPS portatil
+- Batería o UPS portátil
 - Red WiFi local
 
-Politica operativa:
+Política operativa:
 
 - Debe operar sin internet durante la jornada.
 - Debe exportar paquete de jornada al volver a la cabecera.
-- Debe mostrar claramente si quedan datos pendientes de exportacion.
+- Debe mostrar claramente si quedan datos pendientes de exportación.
 - Debe incluir backup antes de apagar o trasladar el equipo.
 
-## Soporte tecnico
+## Soporte técnico
 
-Perfil restringido para diagnostico, mantenimiento y recuperacion.
+Perfil restringido para diagnóstico, mantenimiento y recuperación.
 
 Servicios permitidos:
 
 - `monitoring`
 - `logs`
 - `portainer` si se decide incorporarlo
-- herramientas de diagnostico
+- herramientas de diagnóstico
 
 Restricciones:
 
 - No debe estar habilitado por defecto.
-- No debe ser visible para personal clinico o administrativo.
+- No debe ser visible para personal clínico o administrativo.
 - No debe exponer Docker socket a redes no administrativas.
 - Debe requerir credenciales de soporte.
 - Debe registrar acciones que cambien estado del sistema.
 
-## Mapeo inicial de perfiles tecnicos
+## Mapeo inicial de perfiles técnicos
 
 | Perfil operativo | Compose/profiles esperados |
 | --- | --- |
 | Puesto remoto | `docker-compose.yml` + `compose/ssl.yml` + `compose/status.yml` |
-| Centro de salud | Puesto remoto + `compose/keycloak.yml` o `compose/imaging.yml` segun necesidad |
+| Centro de salud | Puesto remoto + `compose/keycloak.yml` o `compose/imaging.yml` según necesidad |
 | Cabecera de microred | Centro + `--profile hapi` + `--profile monitoring` + `--profile replica` |
-| Brigada | Puesto remoto + configuracion local de jornada/exportacion |
-| Soporte tecnico | `--profile monitoring`, `--profile logs`, futuro `--profile support` |
+| Brigada | Puesto remoto + configuración local de jornada/exportacion |
+| Soporte técnico | `--profile monitoring`, `--profile logs`, futuro `--profile support` |
 
-## Criterios de auditoria
+## Criterios de auditoría
 
 - Cada servicio habilitado por defecto debe estar justificado por perfil operativo.
 - Un puesto remoto debe poder funcionar sin `monitoring`, `hapi`, `keycloak`, `imaging` y `portainer`.
-- Toda herramienta tecnica con capacidad administrativa debe estar separada del semaforo local.
-- El semaforo local debe ser de solo lectura para personal no tecnico.
-- El semaforo local no debe mostrar datos personales ni datos clinicos.
-- Toda actualizacion debe dejar version anterior, version nueva, operador, fecha y resultado.
+- Toda herramienta técnica con capacidad administrativa debe estar separada del semáforo local.
+- El semáforo local debe ser de solo lectura para personal no técnico.
+- El semáforo local no debe mostrar datos personales ni datos clínicos.
+- Toda actualización debe dejar versión anterior, versión nueva, operador, fecha y resultado.
 - Todo backup debe poder verificarse por fecha, checksum y resultado.
 
-Ver tambien:
+Ver también:
 
-- [Semaforo local: privacidad y cumplimiento](status-compliance.md)
-- [Metricas de seed restore y arranque OpenMRS](seed-restore-metrics.md)
+- [Semáforo local: privacidad y cumplimiento](status-compliance.md)
+- [Métricas de seed restore y arranque OpenMRS](seed-restore-metrics.md)

--- a/docs/operations/status-compliance.md
+++ b/docs/operations/status-compliance.md
@@ -1,23 +1,23 @@
-# Semaforo local: privacidad y cumplimiento
+# Semáforo local: privacidad y cumplimiento
 
 Este documento define los controles mínimos para que el semáforo local de SIH Salus apoye disponibilidad operativa sin procesar datos clínicos ni datos personales.
 
 ## Alcance
 
-El semaforo local es un control de disponibilidad y continuidad operativa. No reemplaza controles de seguridad clinica, auditoria del EMR, gestion de usuarios, cifrado, backup, retencion documental ni respuesta a incidentes.
+El semáforo local es un control de disponibilidad y continuidad operativa. No reemplaza controles de seguridad clínica, auditoría del EMR, gestión de usuarios, cifrado, backup, retención documental ni respuesta a incidentes.
 
 ## Principios
 
 - No debe consultar endpoints que devuelvan datos personales o datos de salud.
-- No debe mostrar nombres, documentos, telefonos, direcciones, diagnosticos, resultados, notas clinicas ni identificadores de pacientes.
-- No debe almacenar cuerpos de respuesta con informacion sensible.
-- No debe exponer logs tecnicos al personal clinico o administrativo.
-- Debe separar la vista operativa del soporte tecnico.
-- Debe usar lenguaje de continuidad asistencial, no codigos tecnicos como unica salida.
+- No debe mostrar nombres, documentos, teléfonos, direcciones, diagnósticos, resultados, notas clínicas ni identificadores de pacientes.
+- No debe almacenar cuerpos de respuesta con información sensible.
+- No debe exponer logs técnicos al personal clínico o administrativo.
+- Debe separar la vista operativa del soporte técnico.
+- Debe usar lenguaje de continuidad asistencial, no códigos técnicos como única salida.
 
 ## Uso permitido de Gatus
 
-Gatus puede usarse para verificar disponibilidad de servicios y endpoints tecnicos sin PHI.
+Gatus puede usarse para verificar disponibilidad de servicios y endpoints técnicos sin PHI.
 
 Checks permitidos:
 
@@ -25,64 +25,64 @@ Checks permitidos:
 - `GET /startup`
 - `GET /ready`
 - `GET /openmrs/health/started`
-- `GET /openmrs/ws/rest/v1/session` solo para validar disponibilidad de sesion, sin usuario autenticado
+- `GET /openmrs/ws/rest/v1/session` solo para validar disponibilidad de sesión, sin usuario autenticado
 - Endpoints propios de `status-agent` que devuelvan solo estado operativo
 
 Checks no permitidos:
 
-- Busquedas de pacientes
+- Búsquedas de pacientes
 - Listados de encuentros
-- Observaciones clinicas
+- Observaciones clínicas
 - Resultados de laboratorio
 - Recursos FHIR con datos identificables
-- Logs de aplicacion con contenido clinico
-- Endpoints administrativos que devuelvan secretos, tokens o configuracion sensible
+- Logs de aplicación con contenido clínico
+- Endpoints administrativos que devuelvan secretos, tokens o configuración sensible
 
 ## Controles de acceso
 
-Vista para personal clinico o administrativo:
+Vista para personal clínico o administrativo:
 
 - Solo lectura
-- Sin datos clinicos
+- Sin datos clínicos
 - Sin acceso a Docker
 - Sin acciones destructivas
-- Mensajes de accion recomendada claros
+- Mensajes de acción recomendada claros
 
-Vista para soporte tecnico:
+Vista para soporte técnico:
 
-- Restringida a red administrativa, VPN o tunel SSH
+- Restringida a red administrativa, VPN o túnel SSH
 - Protegida con credenciales
 - Con registro de acciones si permite reinicios, cambios o restauraciones
 
 ## Estados permitidos
 
-El semaforo debe resumir el estado en categorias operativas:
+El semáforo debe resumir el estado en categorías operativas:
 
-- `verde`: puede atender pacientes y guardar informacion
-- `amarillo`: puede atender, pero requiere accion preventiva
-- `rojo`: atencion digital comprometida o riesgo alto de perdida de datos
+- `verde`: puede atender pacientes y guardar información
+- `amarillo`: puede atender, pero requiere acción preventiva
+- `rojo`: atención digital comprometida o riesgo alto de pérdida de datos
 
-Cada estado amarillo o rojo debe incluir una accion recomendada.
+Cada estado amarillo o rojo debe incluir una acción recomendada.
 
 Ejemplos:
 
 - `Conectar USB de backup semanal`
 - `Liberar espacio en disco`
-- `Contactar soporte tecnico`
-- `No apagar el servidor durante restauracion`
+- `Contactar soporte técnico`
+- `No apagar el servidor durante restauración`
 - `Usar contingencia en papel hasta recuperar base de datos`
 
 ## Evidencia auditable
 
-El semaforo puede servir como evidencia de:
+El semáforo puede servir como evidencia de:
 
 - monitoreo de disponibilidad
-- deteccion temprana de fallas
+- detección temprana de fallas
 - continuidad operativa
-- separacion entre estado tecnico y datos clinicos
-- minimizacion de datos expuestos
+- separación entre estado técnico y datos clínicos
+- minimización de datos expuestos
 
-No debe presentarse como cumplimiento total de HIPAA, Ley 29733, Ley 30024 u otra normativa. Debe describirse como un control tecnico parcial dentro de un programa mayor de seguridad, privacidad y continuidad.
+No debe presentarse como cumplimiento total de HIPAA, Ley 29733, Ley 30024 u otra normativa. Debe describirse como un control técnico parcial dentro de un programa mayor de seguridad, privacidad y continuidad.
 
 ## Requisitos para `status-agent`
 
@@ -93,22 +93,22 @@ Campos permitidos:
 - estado general
 - disponibilidad de servicios
 - porcentaje de disco usado
-- fecha del ultimo backup exitoso
-- fecha de ultima exportacion
-- version de SIH Salus
-- version de contenido clinico
-- dias restantes de certificado
-- cantidad de paquetes de sincronizacion pendientes
+- fecha del último backup exitoso
+- fecha de última exportación
+- versión de SIH Salus
+- versión de contenido clínico
+- días restantes de certificado
+- cantidad de paquetes de sincronización pendientes
 
 Campos prohibidos:
 
 - nombres de pacientes
 - documentos de identidad
-- telefonos
+- teléfonos
 - direcciones
 - UUIDs de pacientes
-- diagnosticos
-- resultados clinicos
+- diagnósticos
+- resultados clínicos
 - tokens
 - passwords
 - secretos
@@ -116,4 +116,4 @@ Campos prohibidos:
 
 ## Frase de cumplimiento recomendada
 
-El semaforo local de SIH Salus es un control de disponibilidad y continuidad operativa. Esta disenado para no procesar ni mostrar datos clinicos o personales. No constituye cumplimiento normativo completo por si mismo; complementa controles de autenticacion, autorizacion, auditoria, cifrado, backup, retencion y respuesta a incidentes.
+El semáforo local de SIH Salus es un control de disponibilidad y continuidad operativa. Esta diseñado para no procesar ni mostrar datos clínicos o personales. No constituye cumplimiento normativo completo por sí mismo; complementa controles de autenticación, autorización, auditoría, cifrado, backup, retención y respuesta a incidentes.


### PR DESCRIPTION
## Summary
- Add a minimal SECURITY.md with reporting scope, response targets, and disclosure expectations.
- Add an operations deploy checklist for backup, rollback, smoke tests, and deployment evidence.
- Extend Compose validation CI to save rendered config artifacts and write a GitHub summary.

## Validation
- Not run locally; the updated workflow generates the validation evidence in CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->