### PR TITLE
feat: require individual authorization for Imaging

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -18,6 +18,9 @@ DEPLOYMENT_ENV=development
 # Keycloak + HTTPS:
 # COMPOSE_FILE=docker-compose.yml:compose/keycloak.yml:compose/ssl.yml
 # COMPOSE_PROFILES=keycloak,ssl
+# Imaging autenticado + Keycloak + HTTPS:
+# COMPOSE_FILE=docker-compose.yml:compose/keycloak.yml:compose/imaging-auth.yml:compose/ssl.yml
+# COMPOSE_PROFILES=keycloak,imaging,ssl
 
 # Core
 OPENMRS_DB_USER=openmrs
@@ -42,8 +45,8 @@ STRIP_SOURCE_MAPS=true
 # FRAME_ANCESTORS=
 # FUA_CONFIG=
 # FUA_LOCATIONS=
-# Acceso web a Imaging: localhost y redes privadas por defecto.
-# IMAGING_ACCESS_CONTROL=allow 127.0.0.1; allow 10.0.0.0/8; allow 172.16.0.0/12; allow 192.168.0.0/16; deny all;
+# ACL adicional a la autenticación individual de Imaging.
+# IMAGING_NETWORK_ACCESS_CONTROL=allow 127.0.0.1; allow 10.0.0.0/8; allow 172.16.0.0/12; allow 192.168.0.0/16; deny all;
 
 # FUA: docker compose --profile fua up -d
 # FUA_GENERATOR_IMAGE=marcelius733/fua-generator
@@ -82,6 +85,8 @@ STRIP_SOURCE_MAPS=true
 # KEYCLOAK_PUBLIC_URL=http://localhost/keycloak
 # OPENMRS_REDIRECT_URI=http://localhost/openmrs/*
 # OAUTH2_CLIENT_SECRET=
+# IMAGING_OIDC_CLIENT_SECRET=
+# IMAGING_OAUTH_REDIRECT_URI=http://localhost/imaging/oauth2/callback
 # OAUTH2_ENABLED no es configurable: core=false y el override Keycloak=true.
 
 # Monitoring: docker compose --profile monitoring up -d
@@ -96,6 +101,9 @@ STRIP_SOURCE_MAPS=true
 # ORTHANC_DICOM_CHECK_CALLED_AET=true
 # ORTHANC_STRICT_AET_COMPARISON=true
 # ORTHANC_OVERWRITE_INSTANCES=false
+# Imaging web requiere compose/keycloak.yml + compose/imaging-auth.yml.
+# IMAGING_OAUTH_COOKIE_SECRET=
+# IMAGING_OAUTH_COOKIE_SECURE=false
 
 # Status (requiere cargar compose/status.yml)
 # GATUS_PORT=8086

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       backend: ${{ steps.scope.outputs.backend }}
       backup: ${{ steps.scope.outputs.backup }}
       monitoring: ${{ steps.scope.outputs.monitoring }}
+      imaging: ${{ steps.scope.outputs.imaging }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -36,6 +37,7 @@ jobs:
           backend=true
           backup=true
           monitoring=true
+          imaging=true
 
           can_diff=false
           if [ "$EVENT_NAME" != "workflow_dispatch" ] \
@@ -60,12 +62,19 @@ jobs:
             monitoring=false
           fi
 
+          if [ "$can_diff" = "true" ] \
+            && git diff --quiet "$BASE_SHA" "$GITHUB_SHA" -- .github/workflows/ci.yml compose/core.yml compose/keycloak.yml compose/imaging-auth.yml gateway/ keycloak/ tests/imaging/; then
+            imaging=false
+          fi
+
           echo "backend=$backend" >> "$GITHUB_OUTPUT"
           echo "backup=$backup" >> "$GITHUB_OUTPUT"
           echo "monitoring=$monitoring" >> "$GITHUB_OUTPUT"
+          echo "imaging=$imaging" >> "$GITHUB_OUTPUT"
           echo "Backend build required: $backend"
           echo "Backup round-trip required: $backup"
           echo "Monitoring runtime test required: $monitoring"
+          echo "Imaging auth runtime test required: $imaging"
 
   compose:
     name: Validate Compose
@@ -144,10 +153,22 @@ jobs:
       - name: Verify read-only Docker API
         run: ./tests/monitoring/socket-proxy.sh
 
+  imaging:
+    name: Imaging authorization
+    needs: changes
+    if: needs.changes.outputs.imaging == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Test anonymous denial, authorized access and logout
+        run: ./tests/imaging/auth-gateway.sh
+
   gate:
     name: PR Gate
     if: always()
-    needs: [compose, backend, backup, monitoring]
+    needs: [compose, backend, backup, monitoring, imaging]
     runs-on: ubuntu-latest
     steps:
       - name: Require successful validations
@@ -156,8 +177,10 @@ jobs:
           BACKEND_RESULT: ${{ needs.backend.result }}
           BACKUP_RESULT: ${{ needs.backup.result }}
           MONITORING_RESULT: ${{ needs.monitoring.result }}
+          IMAGING_RESULT: ${{ needs.imaging.result }}
         run: |
           [ "$COMPOSE_RESULT" = "success" ]
           [ "$BACKEND_RESULT" = "success" ] || [ "$BACKEND_RESULT" = "skipped" ]
           [ "$BACKUP_RESULT" = "success" ] || [ "$BACKUP_RESULT" = "skipped" ]
           [ "$MONITORING_RESULT" = "success" ] || [ "$MONITORING_RESULT" = "skipped" ]
+          [ "$IMAGING_RESULT" = "success" ] || [ "$IMAGING_RESULT" = "skipped" ]

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ docker compose --profile fua up -d
 # Core + HAPI FHIR
 docker compose --profile hapi up -d
 
-# Core + Medical Imaging (OHIF/Orthanc)
-docker compose --profile imaging up -d
+# Core + Medical Imaging autenticado (OHIF/Orthanc + Keycloak)
+docker compose -f docker-compose.yml -f compose/keycloak.yml -f compose/imaging-auth.yml --profile keycloak --profile imaging up -d
 
 # Core + Indicadores (Reportes SQL)
 docker compose --profile indicadores up -d
@@ -260,6 +260,7 @@ compose/
   indicadores.yml               # profile: indicadores
   hapi.yml                      # profile: hapi
   imaging.yml                   # profile: imaging
+  imaging-auth.yml              # override OIDC obligatorio para Imaging web
   keycloak.yml                  # profile: keycloak
   monitoring.yml                # profile: monitoring
   status.yml                    # profile: status

--- a/compose/core.yml
+++ b/compose/core.yml
@@ -21,7 +21,10 @@ services:
       FRAME_ANCESTORS: ${FRAME_ANCESTORS:-}
       FUA_CONFIG: ${FUA_CONFIG:-}
       FUA_LOCATIONS: ${FUA_LOCATIONS:-}
-      IMAGING_ACCESS_CONTROL: "${IMAGING_ACCESS_CONTROL:-allow 127.0.0.1; allow 10.0.0.0/8; allow 172.16.0.0/12; allow 192.168.0.0/16; deny all;}"
+      # Imaging web routes are closed unless compose/imaging-auth.yml replaces
+      # this value with network ACL plus OIDC auth_request directives.
+      IMAGING_ACCESS_CONTROL: "deny all;"
+      IMAGING_NETWORK_ACCESS_CONTROL: "${IMAGING_NETWORK_ACCESS_CONTROL:-allow 127.0.0.1; allow 10.0.0.0/8; allow 172.16.0.0/12; allow 192.168.0.0/16; deny all;}"
     healthcheck:
       # /health lo sirve el propio nginx: mide la salud del gateway, no la de
       # los upstreams ("/" redirige 301 al frontend y acoplaria ambos estados).

--- a/compose/imaging-auth.yml
+++ b/compose/imaging-auth.yml
@@ -1,0 +1,60 @@
+# Individual OIDC authorization for OHIF and Orthanc web routes.
+# Load after compose/keycloak.yml and enable the imaging + keycloak profiles.
+
+services:
+  gateway:
+    depends_on:
+      imaging-auth:
+        condition: service_started
+    environment:
+      IMAGING_ACCESS_CONTROL: >-
+        ${IMAGING_NETWORK_ACCESS_CONTROL:-allow 127.0.0.1; allow 10.0.0.0/8; allow 172.16.0.0/12; allow 192.168.0.0/16; deny all;}
+        auth_request /imaging/oauth2/auth;
+        error_page 401 = @imaging_oauth_signin;
+
+  imaging-auth:
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3
+    restart: "unless-stopped"
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    environment:
+      OAUTH2_PROXY_PROVIDER: keycloak-oidc
+      OAUTH2_PROXY_CLIENT_ID: sihsalus-imaging
+      OAUTH2_PROXY_CLIENT_SECRET: ${IMAGING_OIDC_CLIENT_SECRET:?IMAGING_OIDC_CLIENT_SECRET is required for Imaging}
+      OAUTH2_PROXY_COOKIE_SECRET: ${IMAGING_OAUTH_COOKIE_SECRET:?IMAGING_OAUTH_COOKIE_SECRET is required for Imaging}
+      OAUTH2_PROXY_COOKIE_NAME: _sihsalus_imaging
+      OAUTH2_PROXY_COOKIE_SECURE: ${IMAGING_OAUTH_COOKIE_SECURE:-false}
+      OAUTH2_PROXY_COOKIE_HTTPONLY: "true"
+      OAUTH2_PROXY_COOKIE_SAMESITE: lax
+      OAUTH2_PROXY_COOKIE_EXPIRE: 8h
+      OAUTH2_PROXY_COOKIE_REFRESH: 1h
+      OAUTH2_PROXY_HTTP_ADDRESS: 0.0.0.0:4180
+      OAUTH2_PROXY_PROXY_PREFIX: /imaging/oauth2
+      OAUTH2_PROXY_REDIRECT_URL: ${IMAGING_OAUTH_REDIRECT_URI:-http://localhost/imaging/oauth2/callback}
+      OAUTH2_PROXY_OIDC_ISSUER_URL: ${KEYCLOAK_PUBLIC_URL:-http://localhost/keycloak}/realms/openmrs
+      # Browser redirects use the public gateway URL. Token and key retrieval
+      # stay on Docker's internal network and do not depend on hairpin DNS.
+      OAUTH2_PROXY_SKIP_OIDC_DISCOVERY: "true"
+      OAUTH2_PROXY_LOGIN_URL: ${KEYCLOAK_PUBLIC_URL:-http://localhost/keycloak}/realms/openmrs/protocol/openid-connect/auth
+      OAUTH2_PROXY_REDEEM_URL: http://keycloak:8080/realms/openmrs/protocol/openid-connect/token
+      OAUTH2_PROXY_PROFILE_URL: http://keycloak:8080/realms/openmrs/protocol/openid-connect/userinfo
+      OAUTH2_PROXY_OIDC_JWKS_URL: http://keycloak:8080/realms/openmrs/protocol/openid-connect/certs
+      OAUTH2_PROXY_BACKEND_LOGOUT_URL: http://keycloak:8080/realms/openmrs/protocol/openid-connect/logout?id_token_hint={id_token}
+      OAUTH2_PROXY_ALLOWED_ROLES: imaging-access
+      OAUTH2_PROXY_EMAIL_DOMAINS: "*"
+      OAUTH2_PROXY_SCOPE: openid profile email
+      OAUTH2_PROXY_CODE_CHALLENGE_METHOD: S256
+      OAUTH2_PROXY_REVERSE_PROXY: "true"
+      OAUTH2_PROXY_TRUSTED_PROXY_IPS: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+      OAUTH2_PROXY_SET_XAUTHREQUEST: "true"
+      OAUTH2_PROXY_PASS_ACCESS_TOKEN: "false"
+      OAUTH2_PROXY_PASS_AUTHORIZATION_HEADER: "false"
+      OAUTH2_PROXY_PASS_USER_HEADERS: "false"
+      OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true"
+      OAUTH2_PROXY_UPSTREAMS: static://202
+      OAUTH2_PROXY_SILENCE_PING_LOGGING: "true"
+    networks:
+      - auth-network
+      - default
+

--- a/compose/keycloak.yml
+++ b/compose/keycloak.yml
@@ -37,6 +37,8 @@ services:
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-admin}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?KEYCLOAK_ADMIN_PASSWORD is required when Keycloak is enabled}
       OAUTH2_CLIENT_SECRET: ${OAUTH2_CLIENT_SECRET:?OAUTH2_CLIENT_SECRET is required when Keycloak is enabled}
+      IMAGING_OIDC_CLIENT_SECRET: ${IMAGING_OIDC_CLIENT_SECRET:?IMAGING_OIDC_CLIENT_SECRET is required when Keycloak is enabled}
+      IMAGING_OAUTH_REDIRECT_URI: ${IMAGING_OAUTH_REDIRECT_URI:-http://localhost/imaging/oauth2/callback}
       KEYCLOAK_MODE: ${KEYCLOAK_MODE:-development}
       OPENMRS_REDIRECT_URI: ${OPENMRS_REDIRECT_URI:-http://localhost/openmrs/*}
       KC_DB: postgres

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -8,7 +8,7 @@ SIH Salus usa Docker Compose como orquestador de un único host. El diseño prio
 | --- | --- | --- |
 | Entrada | `gateway`, `certbot` | HTTP/HTTPS, CSP, proxy y certificados |
 | Aplicación clínica | `frontend`, `backend`, `db` | SPA OpenMRS, API y datos clínicos |
-| Identidad | `keycloak`, `keycloak-db` | OIDC opcional; no reemplaza roles de OpenMRS |
+| Identidad | `keycloak`, `keycloak-db`, `imaging-auth` | OIDC opcional; autorización Imaging por rol dedicado |
 | Interoperabilidad | `hapi-fhir`, `fua-generator`, `reportes-sql` | Integraciones y reportes con bases separadas |
 | Imágenes | `ohif`, `orthanc`, `orthanc-proxy` | Visualización y almacenamiento DICOM |
 | Operación | `grafana`, `prometheus`, `loki`, `alloy`, `gatus` | Métricas, logs y estado local sin datos clínicos |
@@ -21,6 +21,7 @@ Los servicios se descubren por el DNS de Compose. No se fijan subredes ni direcc
 docker-compose.yml
   + include: core y módulos que solo agregan servicios
   + override opcional: compose/keycloak.yml
+  + override requerido por Imaging: compose/imaging-auth.yml
   + override opcional: compose/ssl.yml
   + override opcional: compose/status.yml
 ```
@@ -47,6 +48,7 @@ La documentación no debe copiar listas completas de variables o comandos si pue
 
 - El core mantiene OAuth2 deshabilitado.
 - El override Keycloak activa OAuth2 en backend, archivo generado y frontend.
+- Las rutas web de Imaging permanecen cerradas sin el override OIDC y exigen `imaging-access` cuando se habilitan.
 - El backend espera la configuración OAuth2 y, cuando aplica, un Keycloak saludable.
 - El override TLS publica el puerto 443.
 - Cada combinación soportada produce un modelo Compose válido.

--- a/docs/operations/deploy-checklist.md
+++ b/docs/operations/deploy-checklist.md
@@ -56,7 +56,7 @@ Registrar:
 - Si aplica, Keycloak redirige a `/openmrs/spa/home`.
 - Si aplica, FUA responde bajo su ruta de gateway.
 - Si aplica, indicadores responde bajo `/openmrs/services/reportes-sql`.
-- Si aplica, imaging/OHIF no muestra errores de gateway/CSP.
+- Si aplica, Imaging rechaza anónimos, acepta solo `imaging-access`, carga OHIF/DICOMweb y `/imaging/logout` exige un nuevo login.
 - Logs de `gateway` y `backend` sin errores nuevos críticos.
 
 ## Cierre

--- a/docs/operations/profiles.md
+++ b/docs/operations/profiles.md
@@ -83,7 +83,7 @@ Requisitos mínimos:
 Política operativa:
 
 - Keycloak solo debe habilitarse si existe procedimiento local de recuperación de usuarios.
-- Imaging solo debe habilitarse si hay responsable de almacenamiento y retención DICOM.
+- Imaging solo debe habilitarse si hay responsable de almacenamiento y retención DICOM, Keycloak y asignación individual del rol `imaging-access`.
 - El panel local debe indicar si el sistema puede atender pacientes y si el último backup es válido.
 
 ## Cabecera de microred
@@ -180,7 +180,7 @@ Restricciones:
 | Perfil operativo | Compose/profiles esperados |
 | --- | --- |
 | Puesto remoto | `docker-compose.yml` + `compose/ssl.yml` + `compose/status.yml` |
-| Centro de salud | Puesto remoto + `compose/keycloak.yml` o `compose/imaging.yml` según necesidad |
+| Centro de salud | Puesto remoto + `compose/keycloak.yml`; Imaging añade `--profile imaging` y `compose/imaging-auth.yml` |
 | Cabecera de microred | Centro + `--profile hapi` + `--profile monitoring` + `--profile replica` |
 | Brigada | Puesto remoto + configuración local de jornada/exportacion |
 | Soporte técnico | `--profile monitoring`, `--profile logs`, futuro `--profile support` |

--- a/gateway/default-ssl.conf.template
+++ b/gateway/default-ssl.conf.template
@@ -187,6 +187,35 @@ server {
     return 503 '<!DOCTYPE html><html lang="es"><head><meta charset="utf-8"><meta http-equiv="refresh" content="30"><title>SIH Salus - Iniciando</title><style>body{font-family:sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#f5f5f5;color:#333}div{text-align:center;max-width:34em;padding:2em}h1{color:#f26522}</style></head><body><div><h1>SIH Salus se est&aacute; iniciando</h1><p>OpenMRS todav&iacute;a est&aacute; terminando su bootstrap. En el primer arranque puede cargar configuraci&oacute;n, conceptos y mappings OCL durante varios minutos.</p><p>Verifica <code>/startup</code> para saber si el backend responde y <code>/ready</code> para saber si ya puede atender tr&aacute;fico cl&iacute;nico.</p><p>Esta p&aacute;gina se actualizar&aacute; autom&aacute;ticamente.</p></div></body></html>';
   }
 
+  # OIDC endpoints for individually authorized Imaging access. Token exchange
+  # remains internal; only browser authorization redirects through Keycloak.
+  location = /imaging/oauth2/auth {
+    internal;
+    set $imaging_auth http://imaging-auth:4180;
+    proxy_pass_request_body off;
+    proxy_set_header Content-Length "";
+    proxy_set_header X-Original-URI $request_uri;
+    proxy_pass $imaging_auth/imaging/oauth2/auth;
+  }
+
+  location /imaging/oauth2/ {
+    ${IMAGING_NETWORK_ACCESS_CONTROL}
+    set $imaging_auth http://imaging-auth:4180;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Auth-Request-Redirect https://$http_host$request_uri;
+    proxy_pass $imaging_auth;
+  }
+
+  location @imaging_oauth_signin {
+    return 302 /imaging/oauth2/start?rd=https://$http_host$request_uri;
+  }
+
+  location = /imaging/logout {
+    return 302 /imaging/oauth2/sign_out?rd=/;
+  }
+
   # OHIF Imaging Viewer
   location = /imaging {
     return 301 /imaging/;

--- a/gateway/default.conf.template
+++ b/gateway/default.conf.template
@@ -160,6 +160,35 @@ server {
     return 503 '<!DOCTYPE html><html lang="es"><head><meta charset="utf-8"><meta http-equiv="refresh" content="30"><title>SIH Salus - Iniciando</title><style>body{font-family:sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#f5f5f5;color:#333}div{text-align:center;max-width:34em;padding:2em}h1{color:#f26522}</style></head><body><div><h1>SIH Salus se est&aacute; iniciando</h1><p>OpenMRS todav&iacute;a est&aacute; terminando su bootstrap. En el primer arranque puede cargar configuraci&oacute;n, conceptos y mappings OCL durante varios minutos.</p><p>Verifica <code>/startup</code> para saber si el backend responde y <code>/ready</code> para saber si ya puede atender tr&aacute;fico cl&iacute;nico.</p><p>Esta p&aacute;gina se actualizar&aacute; autom&aacute;ticamente.</p></div></body></html>';
   }
 
+  # OIDC endpoints for individually authorized Imaging access. These locations
+  # resolve lazily; core keeps all Imaging routes closed when imaging-auth is absent.
+  location = /imaging/oauth2/auth {
+    internal;
+    set $imaging_auth http://imaging-auth:4180;
+    proxy_pass_request_body off;
+    proxy_set_header Content-Length "";
+    proxy_set_header X-Original-URI $request_uri;
+    proxy_pass $imaging_auth/imaging/oauth2/auth;
+  }
+
+  location /imaging/oauth2/ {
+    ${IMAGING_NETWORK_ACCESS_CONTROL}
+    set $imaging_auth http://imaging-auth:4180;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Proto $forwarded_proto;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Auth-Request-Redirect $forwarded_proto://$http_host$request_uri;
+    proxy_pass $imaging_auth;
+  }
+
+  location @imaging_oauth_signin {
+    return 302 /imaging/oauth2/start?rd=$forwarded_proto://$http_host$request_uri;
+  }
+
+  location = /imaging/logout {
+    return 302 /imaging/oauth2/sign_out?rd=/;
+  }
+
   # OHIF Imaging Viewer
   location = /imaging {
     return 301 /imaging/;

--- a/imaging/README.md
+++ b/imaging/README.md
@@ -1,15 +1,24 @@
 # Imaging DICOM
 
-El profile `imaging` agrega OHIF, Orthanc y un proxy DICOMweb. Contiene imágenes médicas y debe operar únicamente en una red clínica controlada o mediante VPN.
+El profile `imaging` agrega OHIF, Orthanc y un proxy DICOMweb. Contiene imágenes médicas, requiere autorización individual con Keycloak y debe operar únicamente en una red clínica controlada o mediante VPN.
 
 ## Arranque seguro por defecto
 
+```env
+COMPOSE_FILE=docker-compose.yml:compose/keycloak.yml:compose/imaging-auth.yml
+COMPOSE_PROFILES=keycloak,imaging
+IMAGING_OIDC_CLIENT_SECRET=<secret-cliente>
+IMAGING_OAUTH_COOKIE_SECRET=<base64-de-32-bytes>
+IMAGING_OAUTH_REDIRECT_URI=http://localhost/imaging/oauth2/callback
+IMAGING_OAUTH_COOKIE_SECURE=false
+```
+
 ```bash
-docker compose --profile imaging up -d
+docker compose up -d --build
 ```
 
 - OHIF y la API HTTP de Orthanc solo publican puertos en localhost.
-- El gateway permite `/imaging`, `/orthanc`, `/dicom-web` y `/wado` únicamente desde localhost y rangos RFC1918.
+- El gateway exige el rol Keycloak `imaging-access` y además limita las rutas a localhost y rangos RFC1918.
 - El puerto DICOM `4242` solo escucha en localhost.
 - Orthanc exige que el Called AET coincida con `ORTHANC`.
 - No se sobrescriben instancias existentes.
@@ -35,13 +44,17 @@ Limita ese puerto en el firewall a las IPs de modalidades autorizadas. DICOM DIM
 
 ## Acceso web
 
-Las rutas web tienen una barrera de red, no autenticación clínica individual. El valor por defecto es:
+Sin `compose/imaging-auth.yml`, las rutas web quedan en `deny all`. El override combina autenticación individual y esta ACL:
 
 ```env
-IMAGING_ACCESS_CONTROL=allow 127.0.0.1; allow 10.0.0.0/8; allow 172.16.0.0/12; allow 192.168.0.0/16; deny all;
+IMAGING_NETWORK_ACCESS_CONTROL=allow 127.0.0.1; allow 10.0.0.0/8; allow 172.16.0.0/12; allow 192.168.0.0/16; deny all;
 ```
 
-Para entornos con rangos distintos, reemplázalo por directivas `allow` específicas y termina siempre con `deny all;`. No habilites acceso público directo.
+Para entornos con rangos distintos, reemplázalo por directivas `allow` específicas y termina siempre con `deny all;`. La ACL no reemplaza el rol. No habilites acceso público directo.
+
+Asigna `imaging-access` solo al personal autorizado. `/imaging/logout` elimina la sesión local y solicita a Keycloak terminar la sesión OIDC. No se entregan access tokens a OHIF ni se incluyen secretos en sus assets.
+
+En HTTPS usa `compose/ssl.yml`, una callback HTTPS exacta y `IMAGING_OAUTH_COOKIE_SECURE=true`.
 
 `ORTHANC_AUTHENTICATION_ENABLED` permanece deshabilitado porque OHIF accede mediante el proxy interno. Activarlo sin configurar credenciales en el proxy rompe DICOMweb y no protege por sí mismo las rutas del gateway.
 
@@ -55,9 +68,9 @@ Para entornos con rangos distintos, reemplázalo por directivas `allow` específ
 ## Diagnóstico
 
 ```bash
-docker compose --profile imaging ps
-docker compose --profile imaging logs --tail 200 orthanc orthanc-proxy ohif gateway
-docker compose --profile imaging port orthanc 4242
+docker compose ps
+docker compose logs --tail 200 imaging-auth keycloak orthanc orthanc-proxy ohif gateway
+docker compose port orthanc 4242
 ```
 
 OHIF usa [app-config.js](app-config.js) y consulta DICOMweb mediante las rutas del gateway.

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -9,6 +9,8 @@ KEYCLOAK_MODE=development
 KEYCLOAK_ADMIN_PASSWORD=<password-seguro>
 KC_DB_PASSWORD=<password-seguro>
 OAUTH2_CLIENT_SECRET=<secret-del-cliente-openmrs>
+IMAGING_OIDC_CLIENT_SECRET=<secret-del-cliente-imaging>
+IMAGING_OAUTH_REDIRECT_URI=http://localhost/imaging/oauth2/callback
 KC_HOSTNAME=http://localhost/keycloak
 KEYCLOAK_PUBLIC_URL=http://localhost/keycloak
 OPENMRS_REDIRECT_URI=http://localhost/openmrs/*
@@ -35,9 +37,10 @@ KEYCLOAK_MODE=production
 KC_HOSTNAME=https://sihsalus.example.org/keycloak
 KEYCLOAK_PUBLIC_URL=https://sihsalus.example.org/keycloak
 OPENMRS_REDIRECT_URI=https://sihsalus.example.org/openmrs/*
+IMAGING_OAUTH_REDIRECT_URI=https://sihsalus.example.org/imaging/oauth2/callback
 ```
 
-En modo `production`, el contenedor exige hostname y redirect URI HTTPS, habilita hostname estricto y arranca con `start --optimized`. Una URL HTTP provoca un fallo temprano. El realm usa Authorization Code Flow y mantiene deshabilitado Direct Access Grants/password grant.
+En modo `production`, el contenedor exige hostname y redirect URI HTTPS, habilita hostname estricto y arranca con `start --optimized`. Una URL HTTP provoca un fallo temprano. El realm usa Authorization Code Flow, mantiene deshabilitado Direct Access Grants/password grant y exige PKCE S256 en el cliente `sihsalus-imaging`.
 
 ## Wiring con OpenMRS
 
@@ -52,7 +55,7 @@ Los endpoints de token, user info y claves usan la red interna Docker. Las redir
 
 ## Usuarios y permisos
 
-El usuario autenticado debe poder mapearse a un usuario OpenMRS. Mantén el mismo `username` en ambos sistemas y administra roles clínicos dentro de OpenMRS. El realm importado configura OIDC, pero no sustituye la autorización clínica.
+El usuario autenticado debe poder mapearse a un usuario OpenMRS. Mantén el mismo `username` en ambos sistemas y administra roles clínicos dentro de OpenMRS. El realm importado configura OIDC, pero no sustituye la autorización clínica. Imaging es la excepción explícita: el gateway exige además el realm role `imaging-access` antes de exponer OHIF o DICOMweb.
 
 ## Diagnóstico
 

--- a/keycloak/entrypoint.sh
+++ b/keycloak/entrypoint.sh
@@ -24,6 +24,14 @@ case "$MODE" in
         ;;
     esac
 
+    case "${IMAGING_OAUTH_REDIRECT_URI:-}" in
+      https://*/imaging/oauth2/callback) ;;
+      *)
+        echo "IMAGING_OAUTH_REDIRECT_URI must be an HTTPS callback ending in /imaging/oauth2/callback in production mode" >&2
+        exit 1
+        ;;
+    esac
+
     export KC_HOSTNAME_STRICT=true
     exec /opt/keycloak/bin/kc.sh start --optimized --import-realm
     ;;

--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -21,10 +21,14 @@
                 "name": "Provider",
                 "description": "Healthcare provider role"
             },
-            {
-                "name": "Clerk",
-                "description": "Data entry clerk role"
-            }
+      {
+        "name": "Clerk",
+        "description": "Data entry clerk role"
+      },
+      {
+        "name": "imaging-access",
+        "description": "Authorized access to OHIF and Orthanc web routes"
+      }
         ]
     },
     "clients": [
@@ -100,16 +104,39 @@
                         "jsonType.label": "String"
                     }
                 }
-            ]
-        }
-    ],
+      ]
+    },
+    {
+      "clientId": "sihsalus-imaging",
+      "name": "SIH Salus Imaging",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "${IMAGING_OIDC_CLIENT_SECRET}",
+      "redirectUris": [
+        "${IMAGING_OAUTH_REDIRECT_URI}"
+      ],
+      "webOrigins": [],
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "fullScopeAllowed": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      }
+    }
+  ],
     "users": [
         {
             "username": "admin",
             "enabled": true,
             "firstName": "Super",
-            "lastName": "User",
-            "email": "admin@openmrs.org",
+      "lastName": "User",
+      "email": "admin@openmrs.org",
+      "emailVerified": true,
             "credentials": [
                 {
                     "type": "password",
@@ -117,9 +144,10 @@
                     "temporary": true
                 }
             ],
-            "realmRoles": [
-                "System Developer"
-            ]
+      "realmRoles": [
+        "System Developer",
+        "imaging-access"
+      ]
         }
     ]
 }

--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -134,6 +134,7 @@ if [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
     check_secret KEYCLOAK_ADMIN_PASSWORD
     check_secret KC_DB_PASSWORD
     check_secret OAUTH2_CLIENT_SECRET
+    check_secret IMAGING_OIDC_CLIENT_SECRET
 
     if [ "$(env_value KEYCLOAK_MODE)" = "production" ]; then
       case "$(env_value KEYCLOAK_PUBLIC_URL)" in
@@ -148,6 +149,28 @@ if [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
         https://*) ok "OPENMRS_REDIRECT_URI uses HTTPS" ;;
         *) fail "OPENMRS_REDIRECT_URI must use HTTPS in production mode" ;;
       esac
+      case "$(env_value IMAGING_OAUTH_REDIRECT_URI)" in
+        https://*/imaging/oauth2/callback) ok "IMAGING_OAUTH_REDIRECT_URI uses the HTTPS callback" ;;
+        *) fail "IMAGING_OAUTH_REDIRECT_URI must be HTTPS and end in /imaging/oauth2/callback" ;;
+      esac
+    fi
+  fi
+  if profile_enabled imaging; then
+    if profile_enabled keycloak; then
+      ok "Imaging includes the Keycloak profile"
+    else
+      fail "Imaging requires the keycloak profile for individual authentication"
+    fi
+    case "$(env_value COMPOSE_FILE)" in
+      *compose/imaging-auth.yml*) ok "Imaging authentication override is selected" ;;
+      *) fail "COMPOSE_FILE must include compose/imaging-auth.yml when Imaging is enabled" ;;
+    esac
+    check_secret IMAGING_OAUTH_COOKIE_SECRET
+
+    if [ "$(env_value DEPLOYMENT_ENV)" = "production" ]; then
+      [ "$(env_value IMAGING_OAUTH_COOKIE_SECURE)" = "true" ] \
+        && ok "Imaging session cookie is HTTPS-only" \
+        || fail "IMAGING_OAUTH_COOKIE_SECURE must be true in production"
     fi
   fi
   if profile_enabled monitoring || profile_enabled logs; then

--- a/scripts/security/secrets_generate.sh
+++ b/scripts/security/secrets_generate.sh
@@ -22,6 +22,10 @@ secret() {
   openssl rand -hex 24
 }
 
+cookie_secret() {
+  openssl rand -base64 32 | tr -- '+/' '-_' | tr -d '\n'
+}
+
 MYSQL_OPENMRS_PASSWORD="$(secret)"
 MYSQL_ROOT_PASSWORD="$(secret)"
 OMRS_DB_REPL_PASSWORD="$(secret)"
@@ -29,6 +33,8 @@ OMRS_DB_BACKUP_PASSWORD="$(secret)"
 KEYCLOAK_ADMIN_PASSWORD="$(secret)"
 KC_DB_PASSWORD="$(secret)"
 OAUTH2_CLIENT_SECRET="$(secret)"
+IMAGING_OIDC_CLIENT_SECRET="$(secret)"
+IMAGING_OAUTH_COOKIE_SECRET="$(cookie_secret)"
 GRAFANA_ADMIN_PASSWORD="$(secret)"
 FUA_DB_PASSWORD="$(secret)"
 FUA_TOKEN="$(secret)"
@@ -41,6 +47,10 @@ cat > "$OUTPUT_FILE" <<EOF
 # This file contains plaintext credentials. Keep mode 600 and store backups encrypted.
 
 DEPLOYMENT_ENV=production
+
+# Enable authenticated Imaging only when it is needed.
+# COMPOSE_FILE=docker-compose.yml:compose/keycloak.yml:compose/imaging-auth.yml:compose/ssl.yml
+# COMPOSE_PROFILES=keycloak,imaging,ssl
 
 # Core MariaDB
 OPENMRS_DB_USER=openmrs
@@ -70,6 +80,12 @@ KEYCLOAK_PORT=8180
 KEYCLOAK_PUBLIC_URL=http://localhost/keycloak
 OPENMRS_REDIRECT_URI=http://localhost/openmrs/*
 OAUTH2_CLIENT_SECRET=${OAUTH2_CLIENT_SECRET}
+IMAGING_OIDC_CLIENT_SECRET=${IMAGING_OIDC_CLIENT_SECRET}
+IMAGING_OAUTH_REDIRECT_URI=http://localhost/imaging/oauth2/callback
+
+# Imaging OIDC session
+IMAGING_OAUTH_COOKIE_SECRET=${IMAGING_OAUTH_COOKIE_SECRET}
+IMAGING_OAUTH_COOKIE_SECURE=true
 
 # Monitoring
 GRAFANA_ADMIN_USER=admin

--- a/scripts/validate-compose.sh
+++ b/scripts/validate-compose.sh
@@ -45,6 +45,8 @@ export SIHSALUS_REPORTES_SQL_DB_PASSWORD="${SIHSALUS_REPORTES_SQL_DB_PASSWORD:-c
 export KEYCLOAK_ADMIN_PASSWORD="${KEYCLOAK_ADMIN_PASSWORD:-ci-keycloak-admin-123}"
 export KC_DB_PASSWORD="${KC_DB_PASSWORD:-ci-keycloak-db-123}"
 export OAUTH2_CLIENT_SECRET="${OAUTH2_CLIENT_SECRET:-ci-oauth2-secret-123}"
+export IMAGING_OIDC_CLIENT_SECRET="${IMAGING_OIDC_CLIENT_SECRET:-ci-imaging-client-secret-123}"
+export IMAGING_OAUTH_COOKIE_SECRET="${IMAGING_OAUTH_COOKIE_SECRET:-QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=}"
 export GRAFANA_ADMIN_PASSWORD="${GRAFANA_ADMIN_PASSWORD:-ci-grafana-password-123}"
 export OMRS_OCL_TOKEN="${OMRS_OCL_TOKEN:-}"
 
@@ -64,15 +66,24 @@ validate indicadores -f docker-compose.yml --profile indicadores
 validate monitoring-logs -f docker-compose.yml --profile monitoring --profile logs
 validate replica -f docker-compose.yml --profile replica
 validate keycloak -f docker-compose.yml -f compose/keycloak.yml --profile keycloak
+validate imaging-auth -f docker-compose.yml -f compose/keycloak.yml -f compose/imaging-auth.yml --profile keycloak --profile imaging
 validate status -f docker-compose.yml -f compose/status.yml --profile status
 validate ssl -f docker-compose.yml -f compose/ssl.yml --profile ssl
 KEYCLOAK_MODE=production \
 KEYCLOAK_PUBLIC_URL=https://sihsalus.example.test/keycloak \
 KC_HOSTNAME=https://sihsalus.example.test/keycloak \
 OPENMRS_REDIRECT_URI=https://sihsalus.example.test/openmrs/* \
+IMAGING_OAUTH_REDIRECT_URI=https://sihsalus.example.test/imaging/oauth2/callback \
 validate keycloak-ssl -f docker-compose.yml -f compose/keycloak.yml -f compose/ssl.yml --profile keycloak --profile ssl
+KEYCLOAK_MODE=production \
+KEYCLOAK_PUBLIC_URL=https://sihsalus.example.test/keycloak \
+KC_HOSTNAME=https://sihsalus.example.test/keycloak \
+OPENMRS_REDIRECT_URI=https://sihsalus.example.test/openmrs/* \
+IMAGING_OAUTH_REDIRECT_URI=https://sihsalus.example.test/imaging/oauth2/callback \
+IMAGING_OAUTH_COOKIE_SECURE=true \
+validate imaging-auth-ssl -f docker-compose.yml -f compose/keycloak.yml -f compose/imaging-auth.yml -f compose/ssl.yml --profile keycloak --profile imaging --profile ssl
 
-python3 - "$EVIDENCE_DIR/core.json" "$EVIDENCE_DIR/keycloak.json" "$EVIDENCE_DIR/ssl.json" "$EVIDENCE_DIR/ci-no-volumes.json" "$EVIDENCE_DIR/imaging.json" "$EVIDENCE_DIR/keycloak-ssl.json" "$EVIDENCE_DIR/monitoring-logs.json" <<'PY'
+python3 - "$EVIDENCE_DIR/core.json" "$EVIDENCE_DIR/keycloak.json" "$EVIDENCE_DIR/ssl.json" "$EVIDENCE_DIR/ci-no-volumes.json" "$EVIDENCE_DIR/imaging.json" "$EVIDENCE_DIR/keycloak-ssl.json" "$EVIDENCE_DIR/monitoring-logs.json" "$EVIDENCE_DIR/imaging-auth.json" "$EVIDENCE_DIR/imaging-auth-ssl.json" keycloak/realm-export.json <<'PY'
 import json
 import sys
 
@@ -93,7 +104,7 @@ def service(config, name):
         fail(f"missing service: {name}")
 
 
-core, keycloak, ssl, ci, imaging, keycloak_ssl, monitoring = map(load, sys.argv[1:])
+core, keycloak, ssl, ci, imaging, keycloak_ssl, monitoring, imaging_auth, imaging_auth_ssl, realm = map(load, sys.argv[1:])
 core_backend = service(core, "backend")
 core_generator = service(core, "backend-oauth2-config")
 
@@ -133,6 +144,8 @@ if not production_keycloak_env.get("KC_HOSTNAME", "").startswith("https://"):
     fail("production Keycloak hostname must use HTTPS")
 if not production_keycloak_env.get("OPENMRS_REDIRECT_URI", "").startswith("https://"):
     fail("production OpenMRS redirect URI must use HTTPS")
+if not production_keycloak_env.get("IMAGING_OAUTH_REDIRECT_URI", "").startswith("https://"):
+    fail("production Imaging redirect URI must use HTTPS")
 
 ssl_ports = service(ssl, "gateway").get("ports", [])
 if not any(str(port.get("target")) == "443" for port in ssl_ports):
@@ -143,8 +156,53 @@ if not any(str(port.get("target")) == "4242" and port.get("host_ip") == "127.0.0
     fail("DICOM port must bind to localhost by default")
 
 imaging_acl = service(imaging, "gateway").get("environment", {}).get("IMAGING_ACCESS_CONTROL", "")
-if "deny all" not in imaging_acl:
-    fail("Imaging gateway routes must deny non-private clients by default")
+if imaging_acl.strip() != "deny all;":
+    fail("Imaging gateway routes must stay closed without the auth override")
+
+imaging_auth_service = service(imaging_auth, "imaging-auth")
+if imaging_auth_service.get("image") != "quay.io/oauth2-proxy/oauth2-proxy:v7.15.3":
+    fail("Imaging auth proxy must use the reviewed pinned version")
+if imaging_auth_service.get("ports"):
+    fail("Imaging auth proxy must not publish host ports")
+
+auth_env = imaging_auth_service.get("environment", {})
+if auth_env.get("OAUTH2_PROXY_PROVIDER") != "keycloak-oidc":
+    fail("Imaging auth must use the Keycloak OIDC provider")
+if auth_env.get("OAUTH2_PROXY_ALLOWED_ROLES") != "imaging-access":
+    fail("Imaging auth must require the explicit imaging-access role")
+if auth_env.get("OAUTH2_PROXY_CODE_CHALLENGE_METHOD") != "S256":
+    fail("Imaging auth must require PKCE S256")
+if "{id_token}" not in auth_env.get("OAUTH2_PROXY_BACKEND_LOGOUT_URL", ""):
+    fail("Imaging logout must terminate the Keycloak session")
+if auth_env.get("OAUTH2_PROXY_PASS_ACCESS_TOKEN") != "false":
+    fail("Imaging auth must not pass reusable access tokens to browser applications")
+
+protected_acl = service(imaging_auth, "gateway").get("environment", {}).get("IMAGING_ACCESS_CONTROL", "")
+if "deny all" not in protected_acl or "auth_request /imaging/oauth2/auth" not in protected_acl:
+    fail("Imaging auth override must combine network ACL and individual authentication")
+if service(imaging_auth, "gateway").get("depends_on", {}).get("imaging-auth", {}).get("condition") != "service_started":
+    fail("gateway must start with the Imaging auth proxy")
+
+production_auth_env = service(imaging_auth_ssl, "imaging-auth").get("environment", {})
+if production_auth_env.get("OAUTH2_PROXY_COOKIE_SECURE") != "true":
+    fail("production Imaging cookies must be HTTPS-only")
+if not production_auth_env.get("OAUTH2_PROXY_REDIRECT_URL", "").startswith("https://"):
+    fail("production Imaging callback must use HTTPS")
+
+realm_roles = {role.get("name") for role in realm.get("roles", {}).get("realm", [])}
+if "imaging-access" not in realm_roles:
+    fail("Keycloak realm must define imaging-access")
+
+imaging_clients = [client for client in realm.get("clients", []) if client.get("clientId") == "sihsalus-imaging"]
+if len(imaging_clients) != 1:
+    fail("Keycloak realm must define one dedicated Imaging client")
+imaging_client = imaging_clients[0]
+if imaging_client.get("directAccessGrantsEnabled") is not False:
+    fail("Imaging client must disable password grants")
+if imaging_client.get("secret") != "${IMAGING_OIDC_CLIENT_SECRET}":
+    fail("Imaging client must use its dedicated injected secret")
+if imaging_client.get("attributes", {}).get("pkce.code.challenge.method") != "S256":
+    fail("Imaging client must require PKCE S256")
 
 if ci.get("volumes"):
     fail("docker-compose-no-volumes.yml must not declare named volumes")

--- a/tests/imaging/auth-gateway.sh
+++ b/tests/imaging/auth-gateway.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d "$ROOT_DIR/.tmp-imaging-auth.XXXXXX")"
+PREFIX="sihsalus-imaging-auth-test-$$"
+NETWORK="${PREFIX}-network"
+UPSTREAM="${PREFIX}-upstream"
+AUTH="${PREFIX}-auth"
+GATEWAY="${PREFIX}-gateway"
+
+cleanup() {
+  docker rm -f "$GATEWAY" "$AUTH" "$UPSTREAM" >/dev/null 2>&1 || true
+  docker network rm "$NETWORK" >/dev/null 2>&1 || true
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+# Validate every oauth2-proxy option without contacting an identity provider.
+docker run --rm \
+  -e OAUTH2_PROXY_PROVIDER=keycloak-oidc \
+  -e OAUTH2_PROXY_CLIENT_ID=sihsalus-imaging \
+  -e OAUTH2_PROXY_CLIENT_SECRET=ci-imaging-client-secret \
+  -e OAUTH2_PROXY_COOKIE_SECRET=QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE= \
+  -e OAUTH2_PROXY_COOKIE_SECURE=false \
+  -e OAUTH2_PROXY_PROXY_PREFIX=/imaging/oauth2 \
+  -e OAUTH2_PROXY_REDIRECT_URL=http://localhost/imaging/oauth2/callback \
+  -e OAUTH2_PROXY_OIDC_ISSUER_URL=http://localhost/keycloak/realms/openmrs \
+  -e OAUTH2_PROXY_SKIP_OIDC_DISCOVERY=true \
+  -e OAUTH2_PROXY_LOGIN_URL=http://localhost/keycloak/realms/openmrs/protocol/openid-connect/auth \
+  -e OAUTH2_PROXY_REDEEM_URL=http://keycloak:8080/realms/openmrs/protocol/openid-connect/token \
+  -e OAUTH2_PROXY_PROFILE_URL=http://keycloak:8080/realms/openmrs/protocol/openid-connect/userinfo \
+  -e OAUTH2_PROXY_OIDC_JWKS_URL=http://keycloak:8080/realms/openmrs/protocol/openid-connect/certs \
+  -e 'OAUTH2_PROXY_BACKEND_LOGOUT_URL=http://keycloak:8080/realms/openmrs/protocol/openid-connect/logout?id_token_hint={id_token}' \
+  -e OAUTH2_PROXY_ALLOWED_ROLES=imaging-access \
+  -e OAUTH2_PROXY_EMAIL_DOMAINS='*' \
+  -e OAUTH2_PROXY_CODE_CHALLENGE_METHOD=S256 \
+  -e OAUTH2_PROXY_UPSTREAMS=static://202 \
+  quay.io/oauth2-proxy/oauth2-proxy:v7.15.3 \
+  --config-test
+
+cat > "$TMP_DIR/upstream.conf" <<'EOF'
+server {
+  listen 80;
+  location / {
+    default_type text/plain;
+    return 200 'mock imaging upstream';
+  }
+}
+EOF
+
+cat > "$TMP_DIR/auth.conf" <<'EOF'
+server {
+  listen 4180;
+
+  location = /imaging/oauth2/auth {
+    if ($cookie__sihsalus_imaging = "allowed") { return 202; }
+    return 401;
+  }
+
+  location = /imaging/oauth2/start {
+    return 302 /keycloak/realms/openmrs/protocol/openid-connect/auth;
+  }
+
+  location = /imaging/oauth2/sign_out {
+    add_header Set-Cookie "_sihsalus_imaging=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax" always;
+    return 302 /;
+  }
+}
+EOF
+
+sed \
+  -e 's|${FRAME_ANCESTORS}||g' \
+  -e 's|${FUA_CONFIG}||g' \
+  -e 's|${FUA_LOCATIONS}||g' \
+  -e 's|${IMAGING_NETWORK_ACCESS_CONTROL}|allow 127.0.0.1; allow 172.16.0.0/12; deny all;|g' \
+  -e 's|${IMAGING_ACCESS_CONTROL}|allow 127.0.0.1; allow 172.16.0.0/12; deny all; auth_request /imaging/oauth2/auth; error_page 401 = @imaging_oauth_signin;|g' \
+  "$ROOT_DIR/gateway/default.conf.template" > "$TMP_DIR/gateway.conf"
+
+docker network create "$NETWORK" >/dev/null
+docker run -d --name "$UPSTREAM" --network "$NETWORK" \
+  --network-alias backend --network-alias frontend --network-alias ohif --network-alias orthanc-proxy \
+  -v "$TMP_DIR/upstream.conf:/etc/nginx/conf.d/default.conf:ro" nginx:1.27-alpine >/dev/null
+docker run -d --name "$AUTH" --network "$NETWORK" --network-alias imaging-auth \
+  -v "$TMP_DIR/auth.conf:/etc/nginx/conf.d/default.conf:ro" nginx:1.27-alpine >/dev/null
+docker run -d --name "$GATEWAY" --network "$NETWORK" -p 127.0.0.1::80 \
+  -v "$TMP_DIR/gateway.conf:/etc/nginx/conf.d/default.conf:ro" nginx:1.27-alpine >/dev/null
+
+PORT="$(docker port "$GATEWAY" 80/tcp | awk -F: 'END { print $NF }')"
+BASE_URL="http://127.0.0.1:${PORT}"
+
+for _ in $(seq 1 30); do
+  curl --fail --silent --show-error "$BASE_URL/health" >/dev/null 2>&1 && break
+  sleep 1
+done
+curl --fail --silent --show-error "$BASE_URL/health" >/dev/null
+
+for path in /imaging/ /orthanc/ /dicom-web/studies /wado; do
+  headers="$TMP_DIR/anonymous.headers"
+  status="$(curl --silent --show-error --output /dev/null --dump-header "$headers" --write-out '%{http_code}' "$BASE_URL$path")"
+  [ "$status" = "302" ]
+  grep -qi '^Location: /imaging/oauth2/start?' "$headers"
+
+  status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+    --cookie '_sihsalus_imaging=allowed' "$BASE_URL$path")"
+  [ "$status" = "200" ]
+done
+
+logout_headers="$TMP_DIR/logout.headers"
+status="$(curl --silent --show-error --output /dev/null --dump-header "$logout_headers" --write-out '%{http_code}' \
+  --cookie '_sihsalus_imaging=allowed' "$BASE_URL/imaging/logout")"
+[ "$status" = "302" ]
+grep -qi '^Location: /imaging/oauth2/sign_out?rd=/' "$logout_headers"
+
+signout_headers="$TMP_DIR/signout.headers"
+status="$(curl --silent --show-error --output /dev/null --dump-header "$signout_headers" --write-out '%{http_code}' \
+  --cookie '_sihsalus_imaging=allowed' "$BASE_URL/imaging/oauth2/sign_out")"
+[ "$status" = "302" ]
+grep -Eqi '^Set-Cookie: _sihsalus_imaging=.*Max-Age=0' "$signout_headers"
+
+echo "[OK] Imaging routes deny anonymous users, accept authorized sessions and clear logout cookies"


### PR DESCRIPTION
## Summary

- protect OHIF, Orthanc, DICOMweb and WADO with a dedicated oauth2-proxy client
- require the explicit Keycloak realm role `imaging-access` while retaining network ACLs
- keep Imaging routes closed when the authentication override is absent
- terminate both the proxy cookie and Keycloak session on logout
- generate and audit separate Imaging OIDC secrets and HTTPS settings
- test anonymous denial, authorized access, logout and Compose security invariants

## Validation

- `./scripts/validate-compose.sh`
- `./tests/imaging/auth-gateway.sh`

Closes #173

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->