### PR TITLE
fix(fua): use safe canonical generator image

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -49,8 +49,8 @@ STRIP_SOURCE_MAPS=true
 # IMAGING_NETWORK_ACCESS_CONTROL=allow 127.0.0.1; allow 10.0.0.0/8; allow 172.16.0.0/12; allow 192.168.0.0/16; deny all;
 
 # FUA: docker compose --profile fua up -d
-# FUA_GENERATOR_IMAGE=marcelius733/fua-generator
-# FUA_GENERATOR_TAG=dev-0.1.7
+# FUA_GENERATOR_IMAGE=ghcr.io/sihsalus/generador-de-fua
+# FUA_GENERATOR_TAG=sha-b426f4d
 # SIHSALUS_FUA_GEN_DB_USER=fuagenerator
 # SIHSALUS_FUA_GEN_DB_PASSWORD=
 # SIHSALUS_FUA_GEN_DB=fuagenerator

--- a/compose/fua.yml
+++ b/compose/fua.yml
@@ -7,16 +7,13 @@
 services:
   fua-generator:
     container_name: sihsalus-fua-generator
-    image: ${FUA_GENERATOR_IMAGE:-marcelius733/fua-generator}:${FUA_GENERATOR_TAG:-dev-0.1.7}
+    image: ${FUA_GENERATOR_IMAGE:-ghcr.io/sihsalus/generador-de-fua}:${FUA_GENERATOR_TAG:-sha-b426f4d}
     restart: "unless-stopped"
     profiles: [ fua ]
-    # fua-generator dev-0.1.7 currently reads these names positionally as
-    # database <- DB_USER, username <- DB_PASSWORD, password <- DB_NAME.
-    # Counter-map them here until the upstream image corrects that wiring.
     environment:
-      DB_USER: ${SIHSALUS_FUA_GEN_DB:-fuagenerator}
-      DB_PASSWORD: ${SIHSALUS_FUA_GEN_DB_USER:-fuagenerator}
-      DB_NAME: ${SIHSALUS_FUA_GEN_DB_PASSWORD:-}
+      DB_USER: ${SIHSALUS_FUA_GEN_DB_USER:-fuagenerator}
+      DB_PASSWORD: ${SIHSALUS_FUA_GEN_DB_PASSWORD:-}
+      DB_NAME: ${SIHSALUS_FUA_GEN_DB:-fuagenerator}
       TOKEN: ${SIHSALUS_FUA_GEN_TOKEN:-}
       SECRET_KEY: ${SIHSALUS_FUA_GEN_SECRET_KEY:-}
       DB_HOST: "fua-generator-db"
@@ -25,25 +22,7 @@ services:
       fua-generator-db:
         condition: service_healthy
     healthcheck:
-      test:
-        - CMD
-        - node
-        - -e
-        - >-
-          const { Client } = require('pg');
-          const client = new Client({
-            database: process.env.DB_USER,
-            user: process.env.DB_PASSWORD,
-            password: process.env.DB_NAME,
-            host: process.env.DB_HOST,
-            port: Number(process.env.DB_PORT)
-          });
-          client.connect()
-            .then(() => client.query('SELECT 1'))
-            .then(() => client.end())
-            .then(() => fetch('http://localhost:3000/'))
-            .then(response => process.exit(response.status === 200 ? 0 : 1))
-            .catch(() => process.exit(1));
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/health').then(response => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/compose/fua.yml
+++ b/compose/fua.yml
@@ -10,10 +10,13 @@ services:
     image: ${FUA_GENERATOR_IMAGE:-marcelius733/fua-generator}:${FUA_GENERATOR_TAG:-dev-0.1.7}
     restart: "unless-stopped"
     profiles: [ fua ]
+    # fua-generator dev-0.1.7 currently reads these names positionally as
+    # database <- DB_USER, username <- DB_PASSWORD, password <- DB_NAME.
+    # Counter-map them here until the upstream image corrects that wiring.
     environment:
-      DB_USER: ${SIHSALUS_FUA_GEN_DB_USER:-fuagenerator}
-      DB_PASSWORD: ${SIHSALUS_FUA_GEN_DB_PASSWORD:-}
-      DB_NAME: ${SIHSALUS_FUA_GEN_DB:-fuagenerator}
+      DB_USER: ${SIHSALUS_FUA_GEN_DB:-fuagenerator}
+      DB_PASSWORD: ${SIHSALUS_FUA_GEN_DB_USER:-fuagenerator}
+      DB_NAME: ${SIHSALUS_FUA_GEN_DB_PASSWORD:-}
       TOKEN: ${SIHSALUS_FUA_GEN_TOKEN:-}
       SECRET_KEY: ${SIHSALUS_FUA_GEN_SECRET_KEY:-}
       DB_HOST: "fua-generator-db"
@@ -22,7 +25,25 @@ services:
       fua-generator-db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD","node","-e","fetch('http://localhost:3000/').then(r => process.exit(r.status === 200 ? 0 : 1)).catch(() => process.exit(1))"]
+      test:
+        - CMD
+        - node
+        - -e
+        - >-
+          const { Client } = require('pg');
+          const client = new Client({
+            database: process.env.DB_USER,
+            user: process.env.DB_PASSWORD,
+            password: process.env.DB_NAME,
+            host: process.env.DB_HOST,
+            port: Number(process.env.DB_PORT)
+          });
+          client.connect()
+            .then(() => client.query('SELECT 1'))
+            .then(() => client.end())
+            .then(() => fetch('http://localhost:3000/'))
+            .then(response => process.exit(response.status === 200 ? 0 : 1))
+            .catch(() => process.exit(1));
       interval: 30s
       timeout: 10s
       retries: 3

--- a/scripts/validate-compose.sh
+++ b/scripts/validate-compose.sh
@@ -49,6 +49,7 @@ export IMAGING_OIDC_CLIENT_SECRET="${IMAGING_OIDC_CLIENT_SECRET:-ci-imaging-clie
 export IMAGING_OAUTH_COOKIE_SECRET="${IMAGING_OAUTH_COOKIE_SECRET:-QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=}"
 export GRAFANA_ADMIN_PASSWORD="${GRAFANA_ADMIN_PASSWORD:-ci-grafana-password-123}"
 export OMRS_OCL_TOKEN="${OMRS_OCL_TOKEN:-}"
+unset FUA_GENERATOR_IMAGE FUA_GENERATOR_TAG
 
 validate() {
   local name="$1"
@@ -83,7 +84,7 @@ IMAGING_OAUTH_REDIRECT_URI=https://sihsalus.example.test/imaging/oauth2/callback
 IMAGING_OAUTH_COOKIE_SECURE=true \
 validate imaging-auth-ssl -f docker-compose.yml -f compose/keycloak.yml -f compose/imaging-auth.yml -f compose/ssl.yml --profile keycloak --profile imaging --profile ssl
 
-python3 - "$EVIDENCE_DIR/core.json" "$EVIDENCE_DIR/keycloak.json" "$EVIDENCE_DIR/ssl.json" "$EVIDENCE_DIR/ci-no-volumes.json" "$EVIDENCE_DIR/imaging.json" "$EVIDENCE_DIR/keycloak-ssl.json" "$EVIDENCE_DIR/monitoring-logs.json" "$EVIDENCE_DIR/imaging-auth.json" "$EVIDENCE_DIR/imaging-auth-ssl.json" keycloak/realm-export.json <<'PY'
+python3 - "$EVIDENCE_DIR/core.json" "$EVIDENCE_DIR/fua.json" "$EVIDENCE_DIR/keycloak.json" "$EVIDENCE_DIR/ssl.json" "$EVIDENCE_DIR/ci-no-volumes.json" "$EVIDENCE_DIR/imaging.json" "$EVIDENCE_DIR/keycloak-ssl.json" "$EVIDENCE_DIR/monitoring-logs.json" "$EVIDENCE_DIR/imaging-auth.json" "$EVIDENCE_DIR/imaging-auth-ssl.json" keycloak/realm-export.json <<'PY'
 import json
 import sys
 
@@ -104,7 +105,7 @@ def service(config, name):
         fail(f"missing service: {name}")
 
 
-core, keycloak, ssl, ci, imaging, keycloak_ssl, monitoring, imaging_auth, imaging_auth_ssl, realm = map(load, sys.argv[1:])
+core, fua, keycloak, ssl, ci, imaging, keycloak_ssl, monitoring, imaging_auth, imaging_auth_ssl, realm = map(load, sys.argv[1:])
 core_backend = service(core, "backend")
 core_generator = service(core, "backend-oauth2-config")
 
@@ -116,6 +117,27 @@ if "keycloak" in core.get("services", {}):
     fail("core must not start Keycloak without the explicit override")
 if core_backend.get("depends_on", {}).get("backend-oauth2-config", {}).get("condition") != "service_completed_successfully":
     fail("backend must wait for OAuth2 config generation")
+
+fua_generator = service(fua, "fua-generator")
+fua_database = service(fua, "fua-generator-db")
+fua_image = fua_generator.get("image", "")
+if not fua_image.startswith("ghcr.io/sihsalus/generador-de-fua:sha-"):
+    fail("FUA generator must default to an immutable official GHCR image")
+
+fua_environment = fua_generator.get("environment", {})
+fua_database_environment = fua_database.get("environment", {})
+fua_database_variables = {
+    "DB_USER": "POSTGRES_USER",
+    "DB_PASSWORD": "POSTGRES_PASSWORD",
+    "DB_NAME": "POSTGRES_DB",
+}
+for application_variable, database_variable in fua_database_variables.items():
+    if fua_environment.get(application_variable) != fua_database_environment.get(database_variable):
+        fail(f"FUA database wiring mismatch: {application_variable} != {database_variable}")
+
+fua_healthcheck = "\n".join(map(str, fua_generator.get("healthcheck", {}).get("test", [])))
+if "http://localhost:3000/health" not in fua_healthcheck:
+    fail("FUA healthcheck must use the database-aware readiness endpoint")
 
 keycloak_backend = service(keycloak, "backend")
 keycloak_generator = service(keycloak, "backend-oauth2-config")


### PR DESCRIPTION
## Objetivo

Eliminar el contramapeo temporal de credenciales causado por la imagen antigua
`marcelius733/fua-generator:dev-0.1.7` y usar una imagen oficial con el wiring
canónico y un arranque no destructivo.

Relacionado con sihsalus/Generador-de-FUA#14.

## Cambios

- Usa `ghcr.io/sihsalus/generador-de-fua:sha-b426f4d`, publicado desde el
  merge seguro del generador.
- Conserva el contrato canónico:
  - `DB_NAME` = base de datos
  - `DB_USER` = usuario
  - `DB_PASSWORD` = contraseña
- Cambia el healthcheck a `GET /health`, que comprueba PostgreSQL.
- Añade invariantes semánticos para impedir que imagen, wiring o healthcheck
  vuelvan a desalinearse.
- Actualiza `.env.template` con la imagen y el tag revisados.

No cambia nombres ni obligatoriedad de variables existentes.

## Validación

- `./scripts/validate-compose.sh`
- `bash -n scripts/validate-compose.sh`
- `git diff --check`
- Manifiesto remoto confirmado para
  `ghcr.io/sihsalus/generador-de-fua:sha-b426f4d`.
- CI upstream: build, tests, CodeQL y publicación GHCR exitosos.

No se levantaron servicios ni contenedores locales.

## Impacto operativo

- Instalaciones que fijaron explícitamente `dev-0.1.7` deben eliminar ese
  override o actualizar `FUA_GENERATOR_IMAGE` y `FUA_GENERATOR_TAG`.
- El generador deja de borrar tablas al arrancar y no abre el puerto si falla
  PostgreSQL.

## Rollback

Revertir este commit restaura la imagen previa, pero no se recomienda porque
esa imagen contiene sincronización destructiva. Respaldar el volumen
PostgreSQL antes del rollout y conservar el tag anterior sólo para diagnóstico.
