### PR TITLE
fix(fua): use production-smoked generator image

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -50,12 +50,14 @@ STRIP_SOURCE_MAPS=true
 
 # FUA: docker compose --profile fua up -d
 # FUA_GENERATOR_IMAGE=ghcr.io/sihsalus/generador-de-fua
-# FUA_GENERATOR_TAG=sha-b426f4d
+# FUA_GENERATOR_TAG=sha-8deb5ba
 # SIHSALUS_FUA_GEN_DB_USER=fuagenerator
 # SIHSALUS_FUA_GEN_DB_PASSWORD=
 # SIHSALUS_FUA_GEN_DB=fuagenerator
 # SIHSALUS_FUA_GEN_TOKEN=
 # SIHSALUS_FUA_GEN_SECRET_KEY=
+# Obligatoria, exactamente 12 bytes; conservar el valor para descifrar FUAs existentes.
+# SIHSALUS_FUA_GEN_ENCRYPTION_KEY=
 
 # Indicadores: docker compose --profile indicadores up -d
 # REPORTES_SQL_IMAGE=ghcr.io/sihsalus/reportes-sql

--- a/compose/fua.yml
+++ b/compose/fua.yml
@@ -7,15 +7,17 @@
 services:
   fua-generator:
     container_name: sihsalus-fua-generator
-    image: ${FUA_GENERATOR_IMAGE:-ghcr.io/sihsalus/generador-de-fua}:${FUA_GENERATOR_TAG:-sha-b426f4d}
+    image: ${FUA_GENERATOR_IMAGE:-ghcr.io/sihsalus/generador-de-fua}:${FUA_GENERATOR_TAG:-sha-8deb5ba}
     restart: "unless-stopped"
     profiles: [ fua ]
     environment:
+      NODE_ENV: "production"
       DB_USER: ${SIHSALUS_FUA_GEN_DB_USER:-fuagenerator}
       DB_PASSWORD: ${SIHSALUS_FUA_GEN_DB_PASSWORD:-}
       DB_NAME: ${SIHSALUS_FUA_GEN_DB:-fuagenerator}
       TOKEN: ${SIHSALUS_FUA_GEN_TOKEN:-}
       SECRET_KEY: ${SIHSALUS_FUA_GEN_SECRET_KEY:-}
+      ENCRYPTION_KEY: ${SIHSALUS_FUA_GEN_ENCRYPTION_KEY:-}
       DB_HOST: "fua-generator-db"
       DB_PORT: "5432"
     depends_on:

--- a/scripts/validate-compose.sh
+++ b/scripts/validate-compose.sh
@@ -40,6 +40,7 @@ export OMRS_DB_REPL_PASSWORD="${OMRS_DB_REPL_PASSWORD:-ci-replica-password-123}"
 export SIHSALUS_FUA_GEN_DB_PASSWORD="${SIHSALUS_FUA_GEN_DB_PASSWORD:-ci-fua-db-password-123}"
 export SIHSALUS_FUA_GEN_TOKEN="${SIHSALUS_FUA_GEN_TOKEN:-ci-fua-token-123}"
 export SIHSALUS_FUA_GEN_SECRET_KEY="${SIHSALUS_FUA_GEN_SECRET_KEY:-ci-fua-secret-123}"
+export SIHSALUS_FUA_GEN_ENCRYPTION_KEY="${SIHSALUS_FUA_GEN_ENCRYPTION_KEY:-ci-smoke-key}"
 export HAPI_DB_PASSWORD="${HAPI_DB_PASSWORD:-ci-hapi-password-123}"
 export SIHSALUS_REPORTES_SQL_DB_PASSWORD="${SIHSALUS_REPORTES_SQL_DB_PASSWORD:-ci-reportes-password-123}"
 export KEYCLOAK_ADMIN_PASSWORD="${KEYCLOAK_ADMIN_PASSWORD:-ci-keycloak-admin-123}"
@@ -126,6 +127,11 @@ if not fua_image.startswith("ghcr.io/sihsalus/generador-de-fua:sha-"):
 
 fua_environment = fua_generator.get("environment", {})
 fua_database_environment = fua_database.get("environment", {})
+if fua_environment.get("NODE_ENV") != "production":
+    fail("FUA generator must run with NODE_ENV=production")
+if len(fua_environment.get("ENCRYPTION_KEY", "").encode("utf-8")) != 12:
+    fail("FUA generator ENCRYPTION_KEY must be exactly 12 bytes")
+
 fua_database_variables = {
     "DB_USER": "POSTGRES_USER",
     "DB_PASSWORD": "POSTGRES_PASSWORD",


### PR DESCRIPTION
## Resumen

- actualiza el generador a `sha-8deb5ba`, publicado desde Generador-de-FUA#15
- fija `NODE_ENV=production` también en Compose
- transmite el contrato existente `ENCRYPTION_KEY`
- documenta `SIHSALUS_FUA_GEN_ENCRYPTION_KEY` como clave obligatoria de exactamente 12 bytes
- agrega invariantes semánticas para modo producción y longitud de la clave

## Evidencia

La imagen fue construida en `main` y, antes de publicarse, el CI:

- inició PostgreSQL 17
- validó `/health`
- reinició la app y comprobó que las tablas no fueran recreadas
- creó un formato y un FUA sintético mediante las rutas reales
- generó un PDF firmado de 2 páginas y 127774 bytes
- verificó nuevamente la firma del PDF

No cambia endpoints ni payloads. La clave real no se guarda en el repositorio y debe configurarse antes de habilitar el profile `fua`.

Follow-up de #184 y sihsalus/Generador-de-FUA#15.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->