### PR TITLE
fix(seed): encrypt and validate release snapshots

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -131,4 +131,5 @@ STRIP_SOURCE_MAPS=true
 # Seed restore (requiere cargar compose/seed.yml)
 # SIHSALUS_SEED_URL=
 # SIHSALUS_SEED_SHA256=
+# SIHSALUS_SEED_PASSPHRASE_FILE=/secure/path/seed-passphrase
 # SIHSALUS_SEED_FORCE=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           fi
 
           if [ "$can_diff" = "true" ] \
-            && git diff --quiet "$BASE_SHA" "$GITHUB_SHA" -- .github/workflows/ci.yml scripts/backup/ tests/backup/; then
+            && git diff --quiet "$BASE_SHA" "$GITHUB_SHA" -- .github/workflows/ci.yml compose/seed.yml scripts/backup/ scripts/seed/ tests/backup/ tests/seed/; then
             backup=false
           fi
 
@@ -140,6 +140,9 @@ jobs:
 
       - name: Test encrypted dump and restore
         run: ./tests/backup/dump-roundtrip.sh
+
+      - name: Test encrypted seed restore
+        run: ./tests/seed/roundtrip.sh
 
   monitoring:
     name: Docker API proxy

--- a/compose/seed.yml
+++ b/compose/seed.yml
@@ -1,26 +1,34 @@
-# One-shot seed restore from a GitHub Release artifact.
+# One-shot encrypted seed restore from a GitHub Release artifact.
 #
-# Usage:
-#   SIHSALUS_SEED_URL=https://github.com/sihsalus/sihsalus/releases/download/<tag>/sihsalus-seed.tar.gz \
-#   docker compose -f docker-compose.yml -f compose/seed.yml --profile seed up -d
+# Bring the normal stack down without deleting volumes, then run only the
+# restore service:
+#   docker compose down
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f compose/seed.yml \
+#     --profile seed \
+#     run --build --rm --no-deps seed
 #
-# To replace existing volumes:
-#   SIHSALUS_SEED_FORCE=true ...
+# After a successful restore, start the normal stack without this override.
+# To replace existing volumes, set SIHSALUS_SEED_FORCE=true.
 
 services:
   seed:
-    image: curlimages/curl:8.10.1
+    image: sihsalus-seed-restore:local
+    build:
+      context: ./scripts/seed
     user: "0:0"
     profiles: [ "seed" ]
     restart: "no"
     environment:
-      SIHSALUS_SEED_URL: ${SIHSALUS_SEED_URL:-}
-      SIHSALUS_SEED_SHA256: ${SIHSALUS_SEED_SHA256:-}
+      SIHSALUS_SEED_URL: ${SIHSALUS_SEED_URL:?set SIHSALUS_SEED_URL}
+      SIHSALUS_SEED_SHA256: ${SIHSALUS_SEED_SHA256:?set SIHSALUS_SEED_SHA256}
+      SIHSALUS_SEED_PASSPHRASE_FILE: /run/secrets/seed_passphrase
       SIHSALUS_SEED_FORCE: ${SIHSALUS_SEED_FORCE:-false}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
-    entrypoint: [ "/bin/sh", "/usr/local/bin/apply-seed.sh" ]
+    secrets:
+      - seed_passphrase
     volumes:
-      - ./scripts/seed/apply-seed.sh:/usr/local/bin/apply-seed.sh:ro
       - db-data:/seed/db-data
       - openmrs-data:/seed/openmrs-data
       - db-fua-generator:/seed/fua-db-data
@@ -29,3 +37,17 @@ services:
     depends_on:
       seed:
         condition: service_completed_successfully
+
+  backend-oauth2-config:
+    depends_on:
+      seed:
+        condition: service_completed_successfully
+
+  fua-generator-db:
+    depends_on:
+      seed:
+        condition: service_completed_successfully
+
+secrets:
+  seed_passphrase:
+    file: ${SIHSALUS_SEED_PASSPHRASE_FILE:?set SIHSALUS_SEED_PASSPHRASE_FILE}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,7 +9,7 @@ Este directorio contiene las herramientas ejecutables del stack. La documentaci�
 | `backup/` | Dump, backup binario, restore y rotación | [backup/README.md](backup/README.md) |
 | `database/` | Inicialización de usuarios y réplica MariaDB | [database/README.md](database/README.md) |
 | `security/` | Generación y auditoría de archivos de entorno | [security/README.md](security/README.md) |
-| `seed/` | Crear y aplicar releases de datos seed | Comentarios de cada script |
+| `seed/` | Crear y aplicar releases cifrados de datos seed | [seed/README.md](seed/README.md) |
 | `utils/` | Inicialización, certificados y soporte operativo | [utils/README.md](utils/README.md) |
 | `validate-compose.sh` | Validación local y de CI de todos los modelos Compose | [compose/README.md](../compose/README.md) |
 | `management-tunnel.sh` | Túneles SSH hacia consolas administrativas locales | Ayuda del script |
@@ -22,6 +22,7 @@ Este directorio contiene las herramientas ejecutables del stack. La documentaci�
 - No ejecutes scripts de restore sin backup previo y ventana operativa aprobada.
 - `BACKUP_ENCRYPTION_PASSWORD` debe venir del ambiente o de un gestor de secretos; Docker Compose no usa Docker secrets en este repositorio.
 - Los backups solo se cifran cuando `BACKUP_ENCRYPTION_PASSWORD` está definida. Producción debe definirla.
+- Los seeds se cifran siempre y requieren `SIHSALUS_SEED_PASSPHRASE_FILE`.
 - No guardes claves, tokens, archivos `.env` o datos clínicos en Git ni en artifacts de CI.
 
 ## Validación rápida

--- a/scripts/seed/Dockerfile
+++ b/scripts/seed/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.23
+
+RUN apk add --no-cache curl openssl
+
+COPY apply-seed.sh /usr/local/bin/apply-seed.sh
+
+ENTRYPOINT [ "/bin/sh", "/usr/local/bin/apply-seed.sh" ]

--- a/scripts/seed/README.md
+++ b/scripts/seed/README.md
@@ -1,0 +1,56 @@
+# Seed cifrado de staging
+
+El seed transporta los volúmenes de MariaDB, OpenMRS y, si existe, PostgreSQL
+del generador FUA. Está pensado únicamente para contenido base sin registros
+clínicos.
+
+## Crear
+
+Requisitos previos:
+
+- backend saludable;
+- `patient`, `obs`, `encounter` y errores OCL en cero;
+- árbol Git limpio;
+- `gh auth` configurado;
+- `SIHSALUS_SEED_PASSPHRASE_FILE` apuntando a un archivo mode `600`, de una sola línea y fuera del repositorio.
+
+```bash
+export SIHSALUS_SEED_PASSPHRASE_FILE="$HOME/.config/sihsalus/seed-passphrase"
+./scripts/seed/create-seed-release.sh
+```
+
+El script detiene solo los cuatro contenedores de aplicación/base involucrados,
+captura los volúmenes en reposo y restablece exactamente los que estaban
+ejecutándose. Publica únicamente el artifact cifrado, su SHA-256 y un manifiesto
+sin secretos. Por defecto crea un draft; publícalo después de validar el asset.
+
+## Restaurar en una máquina limpia
+
+Mantén el stack abajo y no guardes el profile `seed` en `COMPOSE_PROFILES`.
+
+```bash
+export SIHSALUS_SEED_URL='https://github.com/sihsalus/sihsalus/releases/download/<tag>/sihsalus-seed.tar.gz.enc'
+export SIHSALUS_SEED_SHA256='<sha256-del-asset-cifrado>'
+export SIHSALUS_SEED_PASSPHRASE_FILE="$HOME/.config/sihsalus/seed-passphrase"
+
+# Usa aquí el mismo COMPOSE_FILE/perfiles del despliegue normal. No agregues -v.
+docker compose down
+
+docker compose \
+  -f docker-compose.yml \
+  -f compose/seed.yml \
+  --profile seed \
+  run --build --rm --no-deps seed
+
+docker compose up -d
+```
+
+El checksum y el archivo de contraseña son obligatorios. Si algún volumen ya contiene
+datos, el restore falla antes de modificar ninguno. `SIHSALUS_SEED_FORCE=true`
+permite reemplazarlos deliberadamente.
+
+## Seguridad
+
+El artifact incluye credenciales, llaves de OpenMRS y cuentas de la base. No
+publiques la contraseña, no la reutilices como contraseña SSH y no generes un
+seed si el guard SQL detecta datos clínicos o errores OCL.

--- a/scripts/seed/apply-seed.sh
+++ b/scripts/seed/apply-seed.sh
@@ -1,74 +1,191 @@
 #!/bin/sh
 set -eu
 
+umask 077
+
 SEED_URL="${SIHSALUS_SEED_URL:-}"
 SEED_SHA256="${SIHSALUS_SEED_SHA256:-}"
+SEED_PASSPHRASE_FILE="${SIHSALUS_SEED_PASSPHRASE_FILE:-/run/secrets/seed_passphrase}"
 SEED_FORCE="${SIHSALUS_SEED_FORCE:-false}"
-TMP_DIR="/tmp/sihsalus-seed"
-SEED_FILE="$TMP_DIR/seed.tar.gz"
+SEED_ROOT="${SIHSALUS_SEED_ROOT:-/seed}"
+case "$SEED_ROOT" in
+  /|"") echo "[seed] invalid SIHSALUS_SEED_ROOT" >&2; exit 2 ;;
+esac
+case "/$SEED_ROOT/" in
+  */../*) echo "[seed] SIHSALUS_SEED_ROOT must not contain .." >&2; exit 2 ;;
+esac
+
+TMP_DIR="$(mktemp -d /tmp/sihsalus-seed.XXXXXX)"
+CIPHER_FILE="$TMP_DIR/sihsalus-seed.tar.gz.enc"
+SEED_FILE="$TMP_DIR/sihsalus-seed.tar.gz"
 WORK_DIR="$TMP_DIR/work"
+RESTORE_STARTED=false
+RESTORE_COMPLETE=false
+FUA_INCLUDED=false
+
+cleanup() {
+  status=$?
+  trap - EXIT HUP INT TERM
+  if [ "$RESTORE_STARTED" = "true" ] && [ "$RESTORE_COMPLETE" = "false" ]; then
+    echo "[seed] restore failed; clearing partial target data" >&2
+    empty_dir "$DB_DEST" || true
+    empty_dir "$OMRS_DEST" || true
+    [ "$FUA_INCLUDED" = "false" ] || empty_dir "$FUA_DEST" || true
+  fi
+  rm -rf "$TMP_DIR"
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+fail() {
+  echo "[seed] $1" >&2
+  exit "${2:-1}"
+}
 
 has_data() {
-  find "$1" -mindepth 1 -maxdepth 1 | read _unused
+  find "$1" -mindepth 1 -maxdepth 1 | read -r _unused
 }
 
 empty_dir() {
-  rm -rf "$1"/* "$1"/.[!.]* "$1"/..?* 2>/dev/null || true
+  find "$1" -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 }
 
-extract_volume() {
+validate_archive_paths() {
   archive="$1"
-  dest="$2"
-  label="$3"
+  label="$2"
+  list="$TMP_DIR/$label.list"
+  verbose_list="$TMP_DIR/$label.verbose"
 
-  if has_data "$dest"; then
-    if [ "$SEED_FORCE" = "true" ]; then
-      echo "[seed] clearing $label volume"
-      empty_dir "$dest"
-    else
-      echo "[seed] $label volume already has data; set SIHSALUS_SEED_FORCE=true to replace it"
-      return 0
-    fi
-  fi
+  tar tzf "$archive" > "$list" || fail "invalid $label archive" 3
+  tar tvzf "$archive" > "$verbose_list" || fail "invalid $label archive" 3
+  [ -s "$list" ] || fail "empty $label archive" 3
 
-  echo "[seed] extracting $label"
-  tar xzf "$archive" -C "$dest"
+  while IFS= read -r entry; do
+    [ "$entry" != "./" ] || continue
+    clean_entry="${entry#./}"
+    case "$clean_entry" in
+      ""|/*|..|../*|*/../*|*/..)
+        fail "unsafe path in $label archive: $entry" 3
+        ;;
+    esac
+  done < "$list"
+
+  while IFS= read -r entry; do
+    case "$entry" in
+      d*|-*) ;;
+      *) fail "unsupported entry type in $label archive" 3 ;;
+    esac
+  done < "$verbose_list"
 }
 
-[ -n "$SEED_URL" ] || {
-  echo "[seed] SIHSALUS_SEED_URL is required"
-  exit 2
+validate_outer_archive() {
+  validate_archive_paths "$SEED_FILE" outer
+
+  manifest_seen=0
+  db_seen=0
+  openmrs_seen=0
+  fua_seen=0
+  while IFS= read -r entry; do
+    clean_entry="${entry#./}"
+    case "$clean_entry" in
+      manifest.txt) manifest_seen=$((manifest_seen + 1)) ;;
+      db-data.tar.gz) db_seen=$((db_seen + 1)) ;;
+      openmrs-data.tar.gz) openmrs_seen=$((openmrs_seen + 1)) ;;
+      fua-db-data.tar.gz) fua_seen=$((fua_seen + 1)) ;;
+      *) fail "unexpected file in seed bundle: $entry" 3 ;;
+    esac
+  done < "$TMP_DIR/outer.list"
+
+  [ "$manifest_seen" -eq 1 ] || fail "seed bundle must contain one manifest.txt" 3
+  [ "$db_seen" -eq 1 ] || fail "seed bundle must contain one db-data.tar.gz" 3
+  [ "$openmrs_seen" -eq 1 ] || fail "seed bundle must contain one openmrs-data.tar.gz" 3
+  [ "$fua_seen" -le 1 ] || fail "seed bundle contains duplicate fua-db-data.tar.gz" 3
 }
+
+[ -n "$SEED_URL" ] || fail "SIHSALUS_SEED_URL is required" 2
+[ -n "$SEED_SHA256" ] || fail "SIHSALUS_SEED_SHA256 is required" 2
+[ "${#SEED_SHA256}" -eq 64 ] || fail "SIHSALUS_SEED_SHA256 must contain 64 hexadecimal characters" 2
+case "$SEED_SHA256" in
+  *[!0-9a-fA-F]*) fail "SIHSALUS_SEED_SHA256 must contain 64 hexadecimal characters" 2 ;;
+esac
+[ -r "$SEED_PASSPHRASE_FILE" ] && [ -s "$SEED_PASSPHRASE_FILE" ] || \
+  fail "SIHSALUS_SEED_PASSPHRASE_FILE must point to a readable, non-empty file" 2
+case "$SEED_FORCE" in
+  true|false) ;;
+  *) fail "SIHSALUS_SEED_FORCE must be true or false" 2 ;;
+esac
 
 rm -rf "$TMP_DIR"
 mkdir -p "$WORK_DIR"
 
-echo "[seed] downloading $SEED_URL"
-if [ -n "${GITHUB_TOKEN:-}" ]; then
-  curl -fL \
-    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-    -H "Accept: application/octet-stream" \
-    -o "$SEED_FILE" \
-    "$SEED_URL"
-else
-  curl -fL -o "$SEED_FILE" "$SEED_URL"
-fi
+echo "[seed] downloading encrypted artifact"
+case "$SEED_URL" in
+  https://github.com/*|https://api.github.com/*)
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+      curl -fL \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "Accept: application/octet-stream" \
+        -o "$CIPHER_FILE" \
+        "$SEED_URL"
+    else
+      curl -fL -o "$CIPHER_FILE" "$SEED_URL"
+    fi
+    ;;
+  *)
+    curl -fL -o "$CIPHER_FILE" "$SEED_URL"
+    ;;
+esac
 
-if [ -n "$SEED_SHA256" ]; then
-  echo "$SEED_SHA256  $SEED_FILE" | sha256sum -c -
-fi
+echo "$SEED_SHA256  $CIPHER_FILE" | sha256sum -c -
 
+echo "[seed] decrypting artifact"
+openssl enc -d -aes-256-cbc -pbkdf2 -iter 600000 -md sha256 \
+  -pass "file:$SEED_PASSPHRASE_FILE" \
+  -in "$CIPHER_FILE" \
+  -out "$SEED_FILE"
+
+validate_outer_archive
 tar xzf "$SEED_FILE" -C "$WORK_DIR"
-
-[ -f "$WORK_DIR/db-data.tar.gz" ] || { echo "[seed] missing db-data.tar.gz"; exit 3; }
-[ -f "$WORK_DIR/openmrs-data.tar.gz" ] || { echo "[seed] missing openmrs-data.tar.gz"; exit 3; }
-
-extract_volume "$WORK_DIR/db-data.tar.gz" /seed/db-data "db-data"
-extract_volume "$WORK_DIR/openmrs-data.tar.gz" /seed/openmrs-data "openmrs-data"
-
+grep -qx 'seed_format=2' "$WORK_DIR/manifest.txt" || fail "unsupported seed format" 3
+validate_archive_paths "$WORK_DIR/db-data.tar.gz" db-data
+validate_archive_paths "$WORK_DIR/openmrs-data.tar.gz" openmrs-data
 if [ -f "$WORK_DIR/fua-db-data.tar.gz" ]; then
-  extract_volume "$WORK_DIR/fua-db-data.tar.gz" /seed/fua-db-data "fua-db-data"
+  FUA_INCLUDED=true
+  validate_archive_paths "$WORK_DIR/fua-db-data.tar.gz" fua-db-data
 fi
 
-date -u +"%Y-%m-%dT%H:%M:%SZ" > /seed/openmrs-data/.sihsalus-seed-applied
+DB_DEST="$SEED_ROOT/db-data"
+OMRS_DEST="$SEED_ROOT/openmrs-data"
+FUA_DEST="$SEED_ROOT/fua-db-data"
+mkdir -p "$DB_DEST" "$OMRS_DEST" "$FUA_DEST"
+
+if [ "$SEED_FORCE" = "false" ]; then
+  has_data "$DB_DEST" && fail "db-data volume is not empty; use SIHSALUS_SEED_FORCE=true to replace it" 4
+  has_data "$OMRS_DEST" && fail "openmrs-data volume is not empty; use SIHSALUS_SEED_FORCE=true to replace it" 4
+  if [ -f "$WORK_DIR/fua-db-data.tar.gz" ]; then
+    has_data "$FUA_DEST" && fail "fua-db-data volume is not empty; use SIHSALUS_SEED_FORCE=true to replace it" 4
+  fi
+else
+  RESTORE_STARTED=true
+  echo "[seed] clearing target volumes"
+  empty_dir "$DB_DEST"
+  empty_dir "$OMRS_DEST"
+  [ ! -f "$WORK_DIR/fua-db-data.tar.gz" ] || empty_dir "$FUA_DEST"
+fi
+
+RESTORE_STARTED=true
+echo "[seed] extracting db-data"
+tar xzf "$WORK_DIR/db-data.tar.gz" -C "$DB_DEST"
+echo "[seed] extracting openmrs-data"
+tar xzf "$WORK_DIR/openmrs-data.tar.gz" -C "$OMRS_DEST"
+if [ -f "$WORK_DIR/fua-db-data.tar.gz" ]; then
+  echo "[seed] extracting fua-db-data"
+  tar xzf "$WORK_DIR/fua-db-data.tar.gz" -C "$FUA_DEST"
+fi
+
+date -u +"%Y-%m-%dT%H:%M:%SZ" > "$OMRS_DEST/.sihsalus-seed-applied"
+RESTORE_COMPLETE=true
 echo "[seed] done"

--- a/scripts/seed/create-seed-release.sh
+++ b/scripts/seed/create-seed-release.sh
@@ -1,106 +1,295 @@
 #!/bin/sh
 set -eu
 
-GH_REPO="${GH_REPO:-sihsalus/sihsalus}"
-COMPOSE_PROFILES="${COMPOSE_PROFILES:-fua,imaging,monitoring}"
-export COMPOSE_PROFILES
+umask 077
 
-for cmd in docker git gh sha256sum; do
+GH_REPO="${GH_REPO:-sihsalus/sihsalus}"
+SEED_PASSPHRASE_FILE="${SIHSALUS_SEED_PASSPHRASE_FILE:-}"
+SEED_DRAFT="${SIHSALUS_SEED_DRAFT:-true}"
+INCLUDE_FUA="${SIHSALUS_SEED_INCLUDE_FUA:-true}"
+
+for cmd in awk cp docker gh git openssl sha256sum tar; do
   command -v "$cmd" >/dev/null 2>&1 || {
     echo "[seed] missing command: $cmd" >&2
     exit 1
   }
 done
 
+[ -n "$SEED_PASSPHRASE_FILE" ] && [ -r "$SEED_PASSPHRASE_FILE" ] && [ -s "$SEED_PASSPHRASE_FILE" ] || {
+  echo "[seed] SIHSALUS_SEED_PASSPHRASE_FILE must point to a readable, non-empty file" >&2
+  exit 2
+}
+
+case "$SEED_DRAFT" in
+  true|false) ;;
+  *) echo "[seed] SIHSALUS_SEED_DRAFT must be true or false" >&2; exit 2 ;;
+esac
+
+case "$INCLUDE_FUA" in
+  true|false) ;;
+  *) echo "[seed] SIHSALUS_SEED_INCLUDE_FUA must be true or false" >&2; exit 2 ;;
+esac
+
 [ -f docker-compose.yml ] || {
   echo "[seed] run this from the sihsalus repo root" >&2
   exit 1
 }
 
-gh auth status --hostname github.com >/dev/null
-docker compose ps
-docker exec sihsalus-backend curl -fsS http://localhost:8080/openmrs/health/started >/dev/null
+[ -z "$(git status --porcelain)" ] || {
+  echo "[seed] git worktree must be clean" >&2
+  exit 1
+}
 
-GIT_SHA="$(git rev-parse --short HEAD)"
-TAG="${SEED_TAG:-seed-content-${GIT_SHA}-$(date -u +%Y%m%d%H%M%S)}"
+gh auth status --hostname github.com >/dev/null
+docker exec sihsalus-backend curl -fsS \
+  http://localhost:8080/openmrs/health/started >/dev/null
+
+GIT_SHA="$(git rev-parse HEAD)"
+GIT_SHA_SHORT="$(git rev-parse --short HEAD)"
+CONTENT_VERSION="$(awk -F '[<>]' '/<sihsalus-content.version>/{print $3; exit}' backend/pom.xml)"
+CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+TAG="${SEED_TAG:-seed-content-${CONTENT_VERSION}-${GIT_SHA_SHORT}-$(date -u +%Y%m%d%H%M%S)}"
 OUT="${SEED_OUT_DIR:-$HOME/sihsalus-seeds/$TAG}"
-mkdir -p "$OUT"
+WORK_DIR="$OUT/.work-$$"
+ARTIFACT_NAME="sihsalus-seed.tar.gz.enc"
+CHECKSUM_NAME="$ARTIFACT_NAME.sha256"
+
+mkdir -p "$WORK_DIR"
+chmod 700 "$OUT" "$WORK_DIR"
 
 DB_VOL="$(docker inspect sihsalus-db-master --format '{{range .Mounts}}{{if eq .Destination "/var/lib/mysql"}}{{.Name}}{{end}}{{end}}')"
 OMRS_VOL="$(docker inspect sihsalus-backend --format '{{range .Mounts}}{{if eq .Destination "/openmrs/data"}}{{.Name}}{{end}}{{end}}')"
-FUA_VOL="$(docker inspect sihsalus-fua-generator-db --format '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}' 2>/dev/null || true)"
+FUA_VOL=""
+if [ "$INCLUDE_FUA" = "true" ]; then
+  FUA_VOL="$(docker inspect sihsalus-fua-generator-db --format '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}' 2>/dev/null || true)"
+fi
 
 [ -n "$DB_VOL" ] || { echo "[seed] db volume not found" >&2; exit 1; }
 [ -n "$OMRS_VOL" ] || { echo "[seed] openmrs volume not found" >&2; exit 1; }
 
-restart_stack() {
-  docker compose up -d >/dev/null
+is_running() {
+  [ "$(docker inspect --format '{{.State.Running}}' "$1" 2>/dev/null || true)" = "true" ]
+}
+
+BACKEND_WAS_RUNNING=false
+DB_WAS_RUNNING=false
+FUA_WAS_RUNNING=false
+FUA_DB_WAS_RUNNING=false
+is_running sihsalus-backend && BACKEND_WAS_RUNNING=true
+is_running sihsalus-db-master && DB_WAS_RUNNING=true
+is_running sihsalus-fua-generator && FUA_WAS_RUNNING=true
+is_running sihsalus-fua-generator-db && FUA_DB_WAS_RUNNING=true
+
+wait_healthy() {
+  container="$1"
+  max_attempts="$2"
+  attempts=0
+  while [ "$attempts" -lt "$max_attempts" ]; do
+    state="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container" 2>/dev/null || true)"
+    case "$state" in
+      healthy|running) return 0 ;;
+      exited|dead) break ;;
+    esac
+    attempts=$((attempts + 1))
+    sleep 2
+  done
+  echo "[seed] $container did not become healthy" >&2
+  return 1
+}
+
+restart_captured_containers() {
+  restart_failed=false
+
+  [ "$DB_WAS_RUNNING" = "false" ] || docker start sihsalus-db-master >/dev/null || restart_failed=true
+  [ "$FUA_DB_WAS_RUNNING" = "false" ] || docker start sihsalus-fua-generator-db >/dev/null || restart_failed=true
+
+  [ "$DB_WAS_RUNNING" = "false" ] || wait_healthy sihsalus-db-master 60 || restart_failed=true
+  [ "$FUA_DB_WAS_RUNNING" = "false" ] || wait_healthy sihsalus-fua-generator-db 60 || restart_failed=true
+
+  [ "$BACKEND_WAS_RUNNING" = "false" ] || docker start sihsalus-backend >/dev/null || restart_failed=true
+  [ "$FUA_WAS_RUNNING" = "false" ] || docker start sihsalus-fua-generator >/dev/null || restart_failed=true
+
+  [ "$BACKEND_WAS_RUNNING" = "false" ] || wait_healthy sihsalus-backend 450 || restart_failed=true
+  [ "$FUA_WAS_RUNNING" = "false" ] || wait_healthy sihsalus-fua-generator 120 || restart_failed=true
+
+  [ "$restart_failed" = "false" ]
 }
 
 RESTART_NEEDED=false
 cleanup() {
-  if [ "$RESTART_NEEDED" = true ]; then
-    restart_stack
+  status=$?
+  trap - EXIT HUP INT TERM
+  rm -rf "$WORK_DIR"
+  if [ "$RESTART_NEEDED" = "true" ]; then
+    restart_captured_containers || status=1
   fi
+  exit "$status"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
-echo "[seed] stopping writers"
-docker compose stop backend fua-generator >/dev/null 2>&1 || true
-docker compose stop db fua-generator-db >/dev/null 2>&1 || true
 RESTART_NEEDED=true
+echo "[seed] stopping application writers"
+[ "$BACKEND_WAS_RUNNING" = "false" ] || docker stop sihsalus-backend >/dev/null
+[ "$FUA_WAS_RUNNING" = "false" ] || docker stop sihsalus-fua-generator >/dev/null
+
+echo "[seed] checking that the snapshot contains no clinical records or OCL errors"
+SAFETY_COUNTS="$(docker exec sihsalus-db-master sh -ec '
+  MYSQL_PWD="$MYSQL_PASSWORD" mariadb \
+    --user="$MYSQL_USER" \
+    --database="$MYSQL_DATABASE" \
+    --batch --skip-column-names \
+    --execute="SELECT
+      (SELECT COUNT(*) FROM patient),
+      (SELECT COUNT(*) FROM obs),
+      (SELECT COUNT(*) FROM encounter),
+      (SELECT COUNT(*) FROM openconceptlab_item WHERE error_message IS NOT NULL AND LENGTH(error_message) > 0),
+      (SELECT COUNT(*) FROM openconceptlab_import WHERE error_message IS NOT NULL AND LENGTH(error_message) > 0);"
+')"
+set -- $SAFETY_COUNTS
+[ "$#" -eq 5 ] || { echo "[seed] unexpected safety query result" >&2; exit 1; }
+PATIENT_COUNT="$1"
+OBS_COUNT="$2"
+ENCOUNTER_COUNT="$3"
+OCL_ITEM_ERROR_COUNT="$4"
+OCL_IMPORT_ERROR_COUNT="$5"
+
+if [ "$PATIENT_COUNT" -ne 0 ] || [ "$OBS_COUNT" -ne 0 ] || \
+   [ "$ENCOUNTER_COUNT" -ne 0 ] || [ "$OCL_ITEM_ERROR_COUNT" -ne 0 ] || \
+   [ "$OCL_IMPORT_ERROR_COUNT" -ne 0 ]; then
+  echo "[seed] refusing snapshot: patient=$PATIENT_COUNT obs=$OBS_COUNT encounter=$ENCOUNTER_COUNT ocl_item_errors=$OCL_ITEM_ERROR_COUNT ocl_import_errors=$OCL_IMPORT_ERROR_COUNT" >&2
+  exit 3
+fi
+
+echo "[seed] stopping databases"
+[ "$DB_WAS_RUNNING" = "false" ] || docker stop sihsalus-db-master >/dev/null
+[ "$FUA_DB_WAS_RUNNING" = "false" ] || docker stop sihsalus-fua-generator-db >/dev/null
+
+DB_IMAGE="$(docker inspect --format '{{.Config.Image}}' sihsalus-db-master)"
+BACKEND_IMAGE="$(docker inspect --format '{{.Config.Image}}' sihsalus-backend)"
+DB_IMAGE_ID="$(docker inspect --format '{{.Image}}' sihsalus-db-master)"
+BACKEND_IMAGE_ID="$(docker inspect --format '{{.Image}}' sihsalus-backend)"
+BACKEND_REVISION="$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "$BACKEND_IMAGE_ID" 2>/dev/null || true)"
+FUA_DB_IMAGE=""
+FUA_DB_IMAGE_ID=""
+if [ -n "$FUA_VOL" ]; then
+  FUA_DB_IMAGE="$(docker inspect --format '{{.Config.Image}}' sihsalus-fua-generator-db)"
+  FUA_DB_IMAGE_ID="$(docker inspect --format '{{.Image}}' sihsalus-fua-generator-db)"
+fi
+
+cat > "$WORK_DIR/manifest.txt" <<EOF
+seed_format=2
+created_at=$CREATED_AT
+repository=$GH_REPO
+git_sha=$GIT_SHA
+content_version=$CONTENT_VERSION
+backend_image=$BACKEND_IMAGE
+backend_image_id=$BACKEND_IMAGE_ID
+backend_revision=$BACKEND_REVISION
+database_image=$DB_IMAGE
+database_image_id=$DB_IMAGE_ID
+fua_database_image=$FUA_DB_IMAGE
+fua_database_image_id=$FUA_DB_IMAGE_ID
+patient_count=$PATIENT_COUNT
+obs_count=$OBS_COUNT
+encounter_count=$ENCOUNTER_COUNT
+ocl_item_error_count=$OCL_ITEM_ERROR_COUNT
+ocl_import_error_count=$OCL_IMPORT_ERROR_COUNT
+EOF
+cp "$WORK_DIR/manifest.txt" "$OUT/manifest.txt"
 
 echo "[seed] archiving db-data"
-docker run --rm -v "$DB_VOL":/volume:ro -v "$OUT":/backup busybox \
+docker run --rm -v "$DB_VOL":/volume:ro -v "$WORK_DIR":/backup busybox:1.37.0 \
   sh -c 'cd /volume && tar czf /backup/db-data.tar.gz .'
 
 echo "[seed] archiving openmrs-data"
-docker run --rm -v "$OMRS_VOL":/volume:ro -v "$OUT":/backup busybox \
+docker run --rm -v "$OMRS_VOL":/volume:ro -v "$WORK_DIR":/backup busybox:1.37.0 \
   sh -c 'cd /volume && tar czf /backup/openmrs-data.tar.gz .'
 
 if [ -n "$FUA_VOL" ]; then
   echo "[seed] archiving fua-db-data"
-  docker run --rm -v "$FUA_VOL":/volume:ro -v "$OUT":/backup busybox \
+  docker run --rm -v "$FUA_VOL":/volume:ro -v "$WORK_DIR":/backup busybox:1.37.0 \
     sh -c 'cd /volume && tar czf /backup/fua-db-data.tar.gz .'
 fi
 
-echo "[seed] creating seed artifact"
-if [ -f "$OUT/fua-db-data.tar.gz" ]; then
-  tar czf "$OUT/sihsalus-seed.tar.gz" -C "$OUT" db-data.tar.gz openmrs-data.tar.gz fua-db-data.tar.gz
+echo "[seed] creating encrypted artifact"
+if [ -f "$WORK_DIR/fua-db-data.tar.gz" ]; then
+  tar czf "$WORK_DIR/sihsalus-seed.tar.gz" -C "$WORK_DIR" \
+    manifest.txt db-data.tar.gz openmrs-data.tar.gz fua-db-data.tar.gz
 else
-  tar czf "$OUT/sihsalus-seed.tar.gz" -C "$OUT" db-data.tar.gz openmrs-data.tar.gz
+  tar czf "$WORK_DIR/sihsalus-seed.tar.gz" -C "$WORK_DIR" \
+    manifest.txt db-data.tar.gz openmrs-data.tar.gz
 fi
 
-sha256sum "$OUT/sihsalus-seed.tar.gz" | tee "$OUT/sihsalus-seed.tar.gz.sha256" >/dev/null
-SHA256="$(awk '{print $1}' "$OUT/sihsalus-seed.tar.gz.sha256")"
+openssl enc -aes-256-cbc -salt -pbkdf2 -iter 600000 -md sha256 \
+  -pass "file:$SEED_PASSPHRASE_FILE" \
+  -in "$WORK_DIR/sihsalus-seed.tar.gz" \
+  -out "$OUT/$ARTIFACT_NAME.tmp"
+mv "$OUT/$ARTIFACT_NAME.tmp" "$OUT/$ARTIFACT_NAME"
+(cd "$OUT" && sha256sum "$ARTIFACT_NAME" > "$CHECKSUM_NAME")
+SHA256="$(awk '{print $1}' "$OUT/$CHECKSUM_NAME")"
+
+echo "[seed] verifying encrypted artifact"
+openssl enc -d -aes-256-cbc -pbkdf2 -iter 600000 -md sha256 \
+  -pass "file:$SEED_PASSPHRASE_FILE" \
+  -in "$OUT/$ARTIFACT_NAME" \
+  -out "$WORK_DIR/verified-seed.tar.gz"
+tar tzf "$WORK_DIR/verified-seed.tar.gz" >/dev/null
 
 cat > "$OUT/release-notes.md" <<EOF
-Seed volume artifact from ${GH_REPO}.
+Encrypted SIHSALUS seed volume artifact.
 
-Git commit: ${GIT_SHA}
-SHA256: ${SHA256}
+- Git commit: $GIT_SHA
+- Backend revision: $BACKEND_REVISION
+- Content version: $CONTENT_VERSION
+- Created at: $CREATED_AT
+- Patient/obs/encounter rows: $PATIENT_COUNT/$OBS_COUNT/$ENCOUNTER_COUNT
+- OCL item/import errors: $OCL_ITEM_ERROR_COUNT/$OCL_IMPORT_ERROR_COUNT
+- Encryption: AES-256-CBC, PBKDF2-SHA256, 600000 iterations
+- SHA256 (encrypted asset): $SHA256
 
-Restore with:
+The encryption password is intentionally not stored in GitHub.
 
-SIHSALUS_SEED_URL=https://github.com/${GH_REPO}/releases/download/${TAG}/sihsalus-seed.tar.gz
-SIHSALUS_SEED_SHA256=${SHA256}
+Restore with SIHSALUS_SEED_URL, SIHSALUS_SEED_SHA256 and
+SIHSALUS_SEED_PASSPHRASE_FILE using compose/seed.yml.
 EOF
 
-echo "[seed] restarting stack"
-restart_stack
-RESTART_NEEDED=false
-trap - EXIT INT TERM
+echo "[seed] restoring the previous container state"
+if restart_captured_containers; then
+  RESTART_NEEDED=false
+else
+  RESTART_NEEDED=false
+  echo "[seed] previous containers did not recover health; release was not created" >&2
+  exit 1
+fi
 
-echo "[seed] uploading release ${TAG}"
-gh release create "$TAG" \
-  "$OUT/sihsalus-seed.tar.gz#sihsalus-seed.tar.gz" \
-  "$OUT/sihsalus-seed.tar.gz.sha256#sihsalus-seed.tar.gz.sha256" \
-  --repo "$GH_REPO" \
-  --title "$TAG" \
-  --notes-file "$OUT/release-notes.md"
+echo "[seed] uploading release $TAG"
+if [ "$SEED_DRAFT" = "true" ]; then
+  gh release create "$TAG" \
+    "$OUT/$ARTIFACT_NAME#$ARTIFACT_NAME" \
+    "$OUT/$CHECKSUM_NAME#$CHECKSUM_NAME" \
+    "$OUT/manifest.txt#manifest.txt" \
+    --repo "$GH_REPO" \
+    --target "$GIT_SHA" \
+    --title "$TAG" \
+    --notes-file "$OUT/release-notes.md" \
+    --draft
+else
+  gh release create "$TAG" \
+    "$OUT/$ARTIFACT_NAME#$ARTIFACT_NAME" \
+    "$OUT/$CHECKSUM_NAME#$CHECKSUM_NAME" \
+    "$OUT/manifest.txt#manifest.txt" \
+    --repo "$GH_REPO" \
+    --target "$GIT_SHA" \
+    --title "$TAG" \
+    --notes-file "$OUT/release-notes.md" \
+    --latest=false
+fi
 
 echo "[seed] done"
-echo "SIHSALUS_SEED_URL=https://github.com/${GH_REPO}/releases/download/${TAG}/sihsalus-seed.tar.gz"
-echo "SIHSALUS_SEED_SHA256=${SHA256}"
+echo "SEED_TAG=$TAG"
+echo "SIHSALUS_SEED_URL=https://github.com/$GH_REPO/releases/download/$TAG/$ARTIFACT_NAME"
+echo "SIHSALUS_SEED_SHA256=$SHA256"
+echo "SIHSALUS_SEED_DRAFT=$SEED_DRAFT"

--- a/scripts/validate-compose.sh
+++ b/scripts/validate-compose.sh
@@ -50,6 +50,9 @@ export IMAGING_OIDC_CLIENT_SECRET="${IMAGING_OIDC_CLIENT_SECRET:-ci-imaging-clie
 export IMAGING_OAUTH_COOKIE_SECRET="${IMAGING_OAUTH_COOKIE_SECRET:-QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=}"
 export GRAFANA_ADMIN_PASSWORD="${GRAFANA_ADMIN_PASSWORD:-ci-grafana-password-123}"
 export OMRS_OCL_TOKEN="${OMRS_OCL_TOKEN:-}"
+export SIHSALUS_SEED_URL="${SIHSALUS_SEED_URL:-https://example.test/sihsalus-seed.tar.gz.enc}"
+export SIHSALUS_SEED_SHA256="${SIHSALUS_SEED_SHA256:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}"
+export SIHSALUS_SEED_PASSPHRASE_FILE="${SIHSALUS_SEED_PASSPHRASE_FILE:-/dev/null}"
 unset FUA_GENERATOR_IMAGE FUA_GENERATOR_TAG
 
 validate() {
@@ -71,6 +74,7 @@ validate keycloak -f docker-compose.yml -f compose/keycloak.yml --profile keyclo
 validate imaging-auth -f docker-compose.yml -f compose/keycloak.yml -f compose/imaging-auth.yml --profile keycloak --profile imaging
 validate status -f docker-compose.yml -f compose/status.yml --profile status
 validate ssl -f docker-compose.yml -f compose/ssl.yml --profile ssl
+validate seed -f docker-compose.yml -f compose/seed.yml --profile seed --profile fua
 KEYCLOAK_MODE=production \
 KEYCLOAK_PUBLIC_URL=https://sihsalus.example.test/keycloak \
 KC_HOSTNAME=https://sihsalus.example.test/keycloak \
@@ -85,7 +89,7 @@ IMAGING_OAUTH_REDIRECT_URI=https://sihsalus.example.test/imaging/oauth2/callback
 IMAGING_OAUTH_COOKIE_SECURE=true \
 validate imaging-auth-ssl -f docker-compose.yml -f compose/keycloak.yml -f compose/imaging-auth.yml -f compose/ssl.yml --profile keycloak --profile imaging --profile ssl
 
-python3 - "$EVIDENCE_DIR/core.json" "$EVIDENCE_DIR/fua.json" "$EVIDENCE_DIR/keycloak.json" "$EVIDENCE_DIR/ssl.json" "$EVIDENCE_DIR/ci-no-volumes.json" "$EVIDENCE_DIR/imaging.json" "$EVIDENCE_DIR/keycloak-ssl.json" "$EVIDENCE_DIR/monitoring-logs.json" "$EVIDENCE_DIR/imaging-auth.json" "$EVIDENCE_DIR/imaging-auth-ssl.json" keycloak/realm-export.json <<'PY'
+python3 - "$EVIDENCE_DIR/core.json" "$EVIDENCE_DIR/fua.json" "$EVIDENCE_DIR/keycloak.json" "$EVIDENCE_DIR/ssl.json" "$EVIDENCE_DIR/ci-no-volumes.json" "$EVIDENCE_DIR/imaging.json" "$EVIDENCE_DIR/keycloak-ssl.json" "$EVIDENCE_DIR/monitoring-logs.json" "$EVIDENCE_DIR/imaging-auth.json" "$EVIDENCE_DIR/imaging-auth-ssl.json" "$EVIDENCE_DIR/seed.json" keycloak/realm-export.json <<'PY'
 import json
 import sys
 
@@ -106,7 +110,7 @@ def service(config, name):
         fail(f"missing service: {name}")
 
 
-core, fua, keycloak, ssl, ci, imaging, keycloak_ssl, monitoring, imaging_auth, imaging_auth_ssl, realm = map(load, sys.argv[1:])
+core, fua, keycloak, ssl, ci, imaging, keycloak_ssl, monitoring, imaging_auth, imaging_auth_ssl, seed, realm = map(load, sys.argv[1:])
 core_backend = service(core, "backend")
 core_generator = service(core, "backend-oauth2-config")
 
@@ -118,6 +122,13 @@ if "keycloak" in core.get("services", {}):
     fail("core must not start Keycloak without the explicit override")
 if core_backend.get("depends_on", {}).get("backend-oauth2-config", {}).get("condition") != "service_completed_successfully":
     fail("backend must wait for OAuth2 config generation")
+
+seed_service = service(seed, "seed")
+if seed_service.get("environment", {}).get("SIHSALUS_SEED_PASSPHRASE_FILE") != "/run/secrets/seed_passphrase":
+    fail("seed restore must read its passphrase from the mounted Compose secret")
+for writer in ("db", "backend-oauth2-config", "fua-generator-db"):
+    if service(seed, writer).get("depends_on", {}).get("seed", {}).get("condition") != "service_completed_successfully":
+        fail(f"{writer} must wait for the seed restore")
 
 fua_generator = service(fua, "fua-generator")
 fua_database = service(fua, "fua-generator-db")

--- a/tests/seed/roundtrip.sh
+++ b/tests/seed/roundtrip.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+APPLY_SCRIPT="$ROOT_DIR/scripts/seed/apply-seed.sh"
+TEST_DIR="$(mktemp -d /tmp/sihsalus-seed-test.XXXXXX)"
+export COPYFILE_DISABLE=1
+
+cleanup() {
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+for cmd in curl openssl sha256sum tar; do
+  command -v "$cmd" >/dev/null 2>&1 || {
+    echo "[FAIL] missing command: $cmd" >&2
+    exit 1
+  }
+done
+
+PASS_FILE="$TEST_DIR/passphrase"
+WRONG_PASS_FILE="$TEST_DIR/wrong-passphrase"
+printf '%s\n' 'roundtrip-test-passphrase' > "$PASS_FILE"
+printf '%s\n' 'wrong-roundtrip-passphrase' > "$WRONG_PASS_FILE"
+chmod 600 "$PASS_FILE" "$WRONG_PASS_FILE"
+
+FIXTURE="$TEST_DIR/fixture"
+mkdir -p "$FIXTURE/db" "$FIXTURE/openmrs" "$FIXTURE/fua" "$TEST_DIR/bundle"
+printf '%s\n' 'db-sentinel' > "$FIXTURE/db/db.txt"
+printf '%s\n' 'openmrs-sentinel' > "$FIXTURE/openmrs/openmrs.txt"
+printf '%s\n' 'fua-sentinel' > "$FIXTURE/fua/fua.txt"
+
+tar czf "$TEST_DIR/bundle/db-data.tar.gz" -C "$FIXTURE/db" .
+tar czf "$TEST_DIR/bundle/openmrs-data.tar.gz" -C "$FIXTURE/openmrs" .
+tar czf "$TEST_DIR/bundle/fua-db-data.tar.gz" -C "$FIXTURE/fua" .
+cat > "$TEST_DIR/bundle/manifest.txt" <<'EOF'
+seed_format=2
+patient_count=0
+obs_count=0
+encounter_count=0
+ocl_item_error_count=0
+ocl_import_error_count=0
+EOF
+
+PLAIN="$TEST_DIR/sihsalus-seed.tar.gz"
+CIPHER="$PLAIN.enc"
+tar czf "$PLAIN" -C "$TEST_DIR/bundle" \
+  manifest.txt db-data.tar.gz openmrs-data.tar.gz fua-db-data.tar.gz
+openssl enc -aes-256-cbc -salt -pbkdf2 -iter 600000 -md sha256 \
+  -pass "file:$PASS_FILE" -in "$PLAIN" -out "$CIPHER"
+SHA256="$(sha256sum "$CIPHER" | awk '{print $1}')"
+
+run_apply() {
+  dest="$1"
+  pass_file="$2"
+  force="$3"
+  checksum="$4"
+
+  SIHSALUS_SEED_URL="file://$CIPHER" \
+  SIHSALUS_SEED_SHA256="$checksum" \
+  SIHSALUS_SEED_PASSPHRASE_FILE="$pass_file" \
+  SIHSALUS_SEED_FORCE="$force" \
+  SIHSALUS_SEED_ROOT="$dest" \
+    "$APPLY_SCRIPT"
+}
+
+DEST_SUCCESS="$TEST_DIR/dest-success"
+run_apply "$DEST_SUCCESS" "$PASS_FILE" false "$SHA256"
+grep -qx 'db-sentinel' "$DEST_SUCCESS/db-data/db.txt"
+grep -qx 'openmrs-sentinel' "$DEST_SUCCESS/openmrs-data/openmrs.txt"
+grep -qx 'fua-sentinel' "$DEST_SUCCESS/fua-db-data/fua.txt"
+test -s "$DEST_SUCCESS/openmrs-data/.sihsalus-seed-applied"
+
+DEST_NONEMPTY="$TEST_DIR/dest-nonempty"
+mkdir -p "$DEST_NONEMPTY/db-data" "$DEST_NONEMPTY/openmrs-data" "$DEST_NONEMPTY/fua-db-data"
+printf '%s\n' 'keep-me' > "$DEST_NONEMPTY/db-data/existing.txt"
+if run_apply "$DEST_NONEMPTY" "$PASS_FILE" false "$SHA256" >/dev/null 2>&1; then
+  echo "[FAIL] restore unexpectedly accepted a non-empty volume" >&2
+  exit 1
+fi
+grep -qx 'keep-me' "$DEST_NONEMPTY/db-data/existing.txt"
+test ! -e "$DEST_NONEMPTY/openmrs-data/openmrs.txt"
+test ! -e "$DEST_NONEMPTY/openmrs-data/.sihsalus-seed-applied"
+
+run_apply "$DEST_NONEMPTY" "$PASS_FILE" true "$SHA256"
+test ! -e "$DEST_NONEMPTY/db-data/existing.txt"
+grep -qx 'db-sentinel' "$DEST_NONEMPTY/db-data/db.txt"
+
+BAD_SHA="0${SHA256#?}"
+if [ "$BAD_SHA" = "$SHA256" ]; then
+  BAD_SHA="1${SHA256#?}"
+fi
+if run_apply "$TEST_DIR/dest-bad-sha" "$PASS_FILE" false "$BAD_SHA" >/dev/null 2>&1; then
+  echo "[FAIL] restore unexpectedly accepted a bad checksum" >&2
+  exit 1
+fi
+test ! -e "$TEST_DIR/dest-bad-sha/openmrs-data/.sihsalus-seed-applied"
+
+if run_apply "$TEST_DIR/dest-bad-pass" "$WRONG_PASS_FILE" false "$SHA256" >/dev/null 2>&1; then
+  echo "[FAIL] restore unexpectedly accepted a wrong passphrase" >&2
+  exit 1
+fi
+test ! -e "$TEST_DIR/dest-bad-pass/openmrs-data/.sihsalus-seed-applied"
+
+if run_apply "$TEST_DIR/../unsafe-root" "$PASS_FILE" false "$SHA256" >/dev/null 2>&1; then
+  echo "[FAIL] restore unexpectedly accepted a destination containing .." >&2
+  exit 1
+fi
+
+if run_apply "$TEST_DIR/dest-missing-sha" "$PASS_FILE" false "" >/dev/null 2>&1; then
+  echo "[FAIL] restore unexpectedly accepted a missing checksum" >&2
+  exit 1
+fi
+
+echo "[OK] encrypted seed round-trip and negative cases"


### PR DESCRIPTION
## Summary
- encrypt seed releases with a passphrase file and mandatory ciphertext SHA-256
- refuse snapshots containing clinical rows or OCL errors and restore only previously running containers
- make restores fail before touching non-empty volumes, reject unsafe archives, and clear partial restores
- close Compose writer races and add an encrypted round-trip test

## Validation
- ./tests/seed/roundtrip.sh
- ./scripts/validate-compose.sh
- sh/bash syntax checks
- restore helper image built and tool-checked on PowerEdge

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->