### PR TITLE
chore: update content package to 1.16.3

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -62,7 +62,7 @@
     <fua.version>1.0.82</fua.version>
     <imaging.version>1.2.8</imaging.version>
     <!-- Content Packages -->
-    <sihsalus-content.version>1.16.2</sihsalus-content.version>
+    <sihsalus-content.version>1.16.3</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
     <reference-demo-content.version>1.8.0-SNAPSHOT</reference-demo-content.version>
   </properties>


### PR DESCRIPTION
## Resumen\n\n- actualiza sihsalus-content.version de 1.16.2 a 1.16.3\n- incorpora las mejoras normativas CRED publicadas por sihsalus-content#144\n\n## Verificación\n\n- el ZIP sihsalus-content-1.16.3.zip responde HTTP 200 en Maven Central\n- la validación cruzada de sihsalus-content construyó correctamente la imagen backend de SIHSALUS con 1.16.3\n- CI de este PR ejecuta la validación Compose y el empaquetado Maven del backend