### PR TITLE
fix(gateway): resolve backend health routes dynamically

### DIFF
--- a/gateway/default-ssl.conf.template
+++ b/gateway/default-ssl.conf.template
@@ -115,9 +115,10 @@ server {
   # ejecutando Initial Setup o imports de metadata.
   location = /startup {
     access_log off;
+    set $backend_health http://backend:8080;
     proxy_method HEAD;
     proxy_intercept_errors on;
-    proxy_pass http://backend/openmrs/initialsetup;
+    proxy_pass $backend_health/openmrs/initialsetup;
     error_page 301 302 303 307 308 = @backend_started;
     error_page 500 502 503 504 = @backend_not_started;
   }
@@ -136,8 +137,9 @@ server {
   # Readiness global: valida que OpenMRS ya termino su bootstrap completo.
   location = /ready {
     access_log off;
+    set $backend_health http://backend:8080;
     proxy_intercept_errors on;
-    proxy_pass http://backend/openmrs/health/started;
+    proxy_pass $backend_health/openmrs/health/started;
     error_page 500 502 503 504 = @openmrs_not_ready;
   }
 

--- a/gateway/default.conf.template
+++ b/gateway/default.conf.template
@@ -89,9 +89,10 @@ server {
   # ejecutando Initial Setup o imports de metadata.
   location = /startup {
     access_log off;
+    set $backend_health http://backend:8080;
     proxy_method HEAD;
     proxy_intercept_errors on;
-    proxy_pass http://backend/openmrs/initialsetup;
+    proxy_pass $backend_health/openmrs/initialsetup;
     error_page 301 302 303 307 308 = @backend_started;
     error_page 500 502 503 504 = @backend_not_started;
   }
@@ -110,8 +111,9 @@ server {
   # Readiness global: valida que OpenMRS ya termino su bootstrap completo.
   location = /ready {
     access_log off;
+    set $backend_health http://backend:8080;
     proxy_intercept_errors on;
-    proxy_pass http://backend/openmrs/health/started;
+    proxy_pass $backend_health/openmrs/health/started;
     error_page 500 502 503 504 = @openmrs_not_ready;
   }
 

--- a/scripts/seed/create-seed-release.sh
+++ b/scripts/seed/create-seed-release.sh
@@ -112,6 +112,10 @@ restart_captured_containers() {
   [ "$BACKEND_WAS_RUNNING" = "false" ] || wait_healthy sihsalus-backend 450 || restart_failed=true
   [ "$FUA_WAS_RUNNING" = "false" ] || wait_healthy sihsalus-fua-generator 120 || restart_failed=true
 
+  if is_running sihsalus-gateway; then
+    docker exec sihsalus-gateway nginx -s reload >/dev/null || restart_failed=true
+  fi
+
   [ "$restart_failed" = "false" ]
 }
 

--- a/scripts/validate-compose.sh
+++ b/scripts/validate-compose.sh
@@ -14,6 +14,18 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 1
 fi
 
+for gateway_template in gateway/default.conf.template gateway/default-ssl.conf.template; do
+  if grep -Eq 'proxy_pass http://backend(/|:)' "$gateway_template"; then
+    echo "[FAIL] $gateway_template must resolve backend health routes dynamically" >&2
+    exit 1
+  fi
+  if [ "$(grep -c 'set \$backend_health http://backend:8080;' "$gateway_template")" -ne 2 ]; then
+    echo "[FAIL] $gateway_template must define dynamic startup and readiness upstreams" >&2
+    exit 1
+  fi
+done
+echo "[OK] gateway health routes use dynamic Docker DNS"
+
 if [ "$#" -gt 1 ]; then
   echo "Usage: $0 [evidence-directory]" >&2
   exit 2


### PR DESCRIPTION
## Summary
- resolve startup and readiness upstreams through Docker DNS on every request
- reload the gateway after seed snapshot restarts as a compatibility safeguard
- add a Compose validation invariant for both HTTP and HTTPS templates

## Evidence
After the seed snapshot, the backend received a new container IP: normal OpenMRS routes returned 200 while static /ready returned 503. An nginx reload immediately restored /startup=200 and /ready=200.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->