### PR TITLE
fix(gateway): preserve startup response framing

### DIFF
--- a/gateway/default-ssl.conf.template
+++ b/gateway/default-ssl.conf.template
@@ -116,7 +116,6 @@ server {
   location = /startup {
     access_log off;
     set $backend_health http://backend:8080;
-    proxy_method HEAD;
     proxy_intercept_errors on;
     proxy_pass $backend_health/openmrs/initialsetup;
     error_page 301 302 303 307 308 = @backend_started;

--- a/gateway/default.conf.template
+++ b/gateway/default.conf.template
@@ -90,7 +90,6 @@ server {
   location = /startup {
     access_log off;
     set $backend_health http://backend:8080;
-    proxy_method HEAD;
     proxy_intercept_errors on;
     proxy_pass $backend_health/openmrs/initialsetup;
     error_page 301 302 303 307 308 = @backend_started;

--- a/scripts/validate-compose.sh
+++ b/scripts/validate-compose.sh
@@ -23,8 +23,12 @@ for gateway_template in gateway/default.conf.template gateway/default-ssl.conf.t
     echo "[FAIL] $gateway_template must define dynamic startup and readiness upstreams" >&2
     exit 1
   fi
+  if grep -q 'proxy_method HEAD;' "$gateway_template"; then
+    echo "[FAIL] $gateway_template must not discard the startup response body" >&2
+    exit 1
+  fi
 done
-echo "[OK] gateway health routes use dynamic Docker DNS"
+echo "[OK] gateway health routes use dynamic Docker DNS and valid startup framing"
 
 if [ "$#" -gt 1 ]; then
   echo "Usage: $0 [evidence-directory]" >&2

--- a/tests/imaging/auth-gateway.sh
+++ b/tests/imaging/auth-gateway.sh
@@ -42,6 +42,7 @@ docker run --rm \
 cat > "$TMP_DIR/upstream.conf" <<'EOF'
 server {
   listen 80;
+  listen 8080;
   location / {
     default_type text/plain;
     return 200 'mock imaging upstream';

--- a/tests/imaging/auth-gateway.sh
+++ b/tests/imaging/auth-gateway.sh
@@ -95,6 +95,17 @@ for _ in $(seq 1 30); do
 done
 curl --fail --silent --show-error "$BASE_URL/health" >/dev/null
 
+startup_headers="$TMP_DIR/startup.headers"
+startup_body="$TMP_DIR/startup.body"
+status="$(curl --http1.1 --max-time 5 --silent --show-error \
+  --output "$startup_body" --dump-header "$startup_headers" \
+  --write-out '%{http_code}' "$BASE_URL/startup")"
+[ "$status" = "200" ]
+startup_bytes="$(wc -c < "$startup_body" | tr -d '[:space:]')"
+content_lengths="$(awk 'tolower($1) == "content-length:" { gsub(/\r/, "", $2); print $2 }' "$startup_headers")"
+[ "$content_lengths" = "$startup_bytes" ]
+grep -qi '^X-Content-Type-Options: nosniff' "$startup_headers"
+
 for path in /imaging/ /orthanc/ /dicom-web/studies /wado; do
   headers="$TMP_DIR/anonymous.headers"
   status="$(curl --silent --show-error --output /dev/null --dump-header "$headers" --write-out '%{http_code}' "$BASE_URL$path")"
@@ -118,4 +129,4 @@ status="$(curl --silent --show-error --output /dev/null --dump-header "$signout_
 [ "$status" = "302" ]
 grep -Eqi '^Set-Cookie: _sihsalus_imaging=.*Max-Age=0' "$signout_headers"
 
-echo "[OK] Imaging routes deny anonymous users, accept authorized sessions and clear logout cookies"
+echo "[OK] Gateway startup framing and imaging authorization routes"


### PR DESCRIPTION
The startup proxy forced HEAD for client GET requests, forwarded the upstream Content-Length, and sent no body. This caused HTTP/2 PROTOCOL_ERROR and HTTP/1.1 timeouts. Preserve the client method so response framing remains valid in both gateway templates, and add a compose validation guard. Verified with an isolated real Nginx gateway and an 853-byte backend response: HTTP 200, one Content-Length, and 853 bytes received.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->