### PR TITLE
chore: update SIHSALUS content package to 1.18.0

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -62,7 +62,7 @@
     <fua.version>1.0.85</fua.version>
     <imaging.version>1.2.8</imaging.version>
     <!-- Content Packages -->
-    <sihsalus-content.version>1.17.0</sihsalus-content.version>
+    <sihsalus-content.version>1.18.0</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
     <reference-demo-content.version>1.8.0-SNAPSHOT</reference-demo-content.version>
   </properties>


### PR DESCRIPTION
## Summary

- update `sihsalus-content` from `1.17.0` to `1.18.0`
- coordinate the content change with frontend PR sihsalus/sihsalus-frontend#597

## Deployment dependency

Frontend PR #597 was merged before this PR. Do not deploy content `1.18.0` with an older frontend image. Deploy the frontend image produced from merge commit `3dbc1fa45c63f3e053f91a801308fac3435a97f5` before or together with this content release.

Expected immutable source tag:

`FRONTEND_SOURCE_TAG=sha-3dbc1fa45c63f3e053f91a801308fac3435a97f5`

The tag was still propagating in GHCR when this PR was opened. Verify it exists before deployment.

## Validation

- Maven Central POM and ZIP `1.18.0`: HTTP 200
- `mvn --batch-mode --update-snapshots --file backend/pom.xml clean package`: BUILD SUCCESS
- resolved companion FUA module: `1.0.85`
