### PR TITLE
chore: update SIHSALUS content package to 1.20.0

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -62,7 +62,7 @@
     <fua.version>1.0.86</fua.version>
     <imaging.version>1.2.8</imaging.version>
     <!-- Content Packages -->
-    <sihsalus-content.version>1.18.0</sihsalus-content.version>
+    <sihsalus-content.version>1.20.0</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
     <reference-demo-content.version>1.8.0-SNAPSHOT</reference-demo-content.version>
   </properties>


### PR DESCRIPTION
## Summary

- update `sihsalus-content` from `1.18.0` to `1.20.0`
- consume the release produced by sihsalus/sihsalus-content#162

## Publication dependency

At PR creation time Maven Central still reports `1.19.2` as latest and POM/ZIP `1.20.0` return HTTP 404. Do not merge until publication and the integrated SIHSALUS validation complete successfully.

- Publication: https://github.com/sihsalus/sihsalus-content/actions/runs/29546298780
- Integrated validation: https://github.com/sihsalus/sihsalus-content/actions/runs/29546299025

## Validation

- CI backend build will run automatically
- local Maven build pending public artifact propagation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->