### PR TITLE
chore: upgrade OpenMRS Core and FHIR2

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG OPENMRS_BUILD_IMAGE=openmrs/openmrs-core:2.8.x-dev-amazoncorretto-21
-ARG OPENMRS_RUNTIME_IMAGE=openmrs/openmrs-core:2.8.7-amazoncorretto-21
+ARG OPENMRS_RUNTIME_IMAGE=openmrs/openmrs-core:2.8.8-amazoncorretto-21
 
 ### Build Stage
 # The dev tag provides Maven/OpenMRS build tooling for the 2.8 line.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,9 @@
 # syntax=docker/dockerfile:1
 
 ARG OPENMRS_BUILD_IMAGE=openmrs/openmrs-core:2.8.x-dev-amazoncorretto-21
-ARG OPENMRS_RUNTIME_IMAGE=openmrs/openmrs-core:2.8.8-amazoncorretto-21
+# Pin the multi-arch runtime used by Reference Application 3.7.1. The Core
+# 2.8.8 WAR is copied below; its exact runtime tag contains a reverted DB check.
+ARG OPENMRS_RUNTIME_IMAGE=openmrs/openmrs-core:2.8.x-amazoncorretto-21@sha256:7f08dd72400c08d4fbf584cc9ac7cf17d96a2ae5fa0c43b4dc60a40ea7d0b760
 
 ### Build Stage
 # The dev tag provides Maven/OpenMRS build tooling for the 2.8 line.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -25,9 +25,9 @@
 
     <!-- track module versions
          we do so here so that we can utilise Maven to track updates, etc. -->
-    <openmrs.version>2.8.7</openmrs.version>
+    <openmrs.version>2.8.8</openmrs.version>
     <initializer.version>2.12.0</initializer.version>
-    <fhir2.version>4.1.0</fhir2.version>
+    <fhir2.version>4.2.0</fhir2.version>
     <webservices.rest.version>3.5.0</webservices.rest.version>
     <addresshierarchy.version>2.21.0</addresshierarchy.version>
     <patientdocuments.version>1.1.0</patientdocuments.version>


### PR DESCRIPTION
## Objetivo

Alinear el backend con OpenMRS Reference Application 3.7.1 y adoptar las correcciones estables de Core 2.8.8 y FHIR2 4.2.0.

## Cambios

- Actualiza OpenMRS Core de `2.8.7` a `2.8.8`.
- Actualiza FHIR2 de `4.1.0` a `4.2.0`.
- Fija el runtime al digest multi-arquitectura exacto usado por Reference App 3.7.1: `openmrs/openmrs-core:2.8.x-amazoncorretto-21@sha256:7f08dd72400c08d4fbf584cc9ac7cf17d96a2ae5fa0c43b4dc60a40ea7d0b760`.
- No cambia variables de entorno, perfiles Compose, credenciales ni datos.

## Decisión de compatibilidad

El tag runtime exacto `2.8.8-amazoncorretto-21` contiene un chequeo de autenticación que OpenMRS revirtió porque rompe Reference App: Amazon Linux 2 expone el cliente como `mysql`, no `mariadb`, y el chequeo también bloquea ciertos installs frescos. En vez de mantener un workaround propio, este PR usa la misma base inmutable que RefApp 3.7.1 y copia encima el WAR Core 2.8.8 construido por SIHSALUS. La base conserva Tomcat 9.0.120 y Corretto 21.0.11.

Referencias: [RefApp 3.7.1 Dockerfile](https://github.com/openmrs/openmrs-distro-referenceapplication/blob/3.7.1/Dockerfile#L30-L35), [revert de OpenMRS Core](https://github.com/openmrs/openmrs-core/commit/97d8705782e4ad2323b49efb73b8118171563e9f), [fix completo aún pendiente](https://github.com/openmrs/openmrs-core/pull/6300).

## Validación remota

- [x] GitHub CI: build del distro con JDK 8.
- [x] GitHub CI: validación de todas las combinaciones Compose e invariantes.
- [x] CodeQL y PR Gate.
- [x] [Build Backend linux/amd64](https://github.com/sihsalus/sihsalus/actions/runs/29590334835), publicación y firma Cosign.
- [x] Imagen: `ghcr.io/sihsalus/sihsalus-backend:sha-b38c6829b5075bea555254d586a01101bb7f8e59`.
- [x] Digest: `sha256:36041b3a88c10d44c9bd945d2f63242e16dac65f31e83be67e4d7648c06f921c`.

## Impacto y rollback

Es un upgrade de parche de Core y una versión estable de FHIR2. Core 2.8.8 mejora diagnóstico de arranque y manejo de credenciales; FHIR2 4.2.0 incorpora soporte actualizado de duraciones SNOMED/UCUM. No se prevé migración manual: OpenMRS conserva su actualización automática de esquema.

Para rollback, revertir los dos commits de este PR restaura Core 2.8.7, FHIR2 4.1.0 y el runtime anterior; luego se reconstruye y despliega la imagen previa.