### PR TITLE
fix(frontend): prevent stale SPA entry cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Test frontend cache policy
+        run: ./tests/frontend/cache-policy.sh
+
       - name: Validate models and invariants
         run: ./scripts/validate-compose.sh compose-validation
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -40,7 +40,7 @@ http {
 
     # Content-addressed assets are immutable. Rspack currently emits both
     # dot-hash entry aliases and hyphen-hash lazy chunks.
-    location ~* ^/.+[.-][a-f0-9]{8,}\.(?:js|css)$ {
+    location ~* "^/.+[.-][a-f0-9]{8,}\.(?:js|css)$" {
       add_header Cache-Control "public, max-age=31536000, immutable" always;
       try_files $uri =404;
     }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -32,27 +32,37 @@ http {
     root    /usr/share/nginx/html;
     index   index.html;
 
-    # never cache the service-worker
-    location ~* service-worker\.js$ {
-      expires -1d;
+    # Mutable SPA control files must always be revalidated.
+    location ~* ^/(?:service-worker\.js|index\.html|importmap\.json|routes\.registry\.json|frontend\.json|build-info\.json)$ {
+      add_header Cache-Control "no-cache, no-store, must-revalidate" always;
       try_files $uri =404;
     }
 
-    location ~* (\.js|openmrs\.(\w*\.)?css)$ {
-      expires 1y;
+    # Content-addressed assets are immutable. Rspack currently emits both
+    # dot-hash entry aliases and hyphen-hash lazy chunks.
+    location ~* ^/.+[.-][a-f0-9]{8,}\.(?:js|css)$ {
+      add_header Cache-Control "public, max-age=31536000, immutable" always;
+      try_files $uri =404;
+    }
+
+    # Any JavaScript or CSS without a content hash is mutable. This includes
+    # root-level module-federation entrypoints such as openmrs-esm-*.js: their
+    # stable filenames can reference different lazy chunks after a release.
+    location ~* \.(?:js|css)$ {
+      add_header Cache-Control "no-cache, no-store, must-revalidate" always;
       try_files $uri =404;
     }
 
     # handle anything with a "." that's not an HTML file
     # assume it's a static file
     location ~* \.(?!html?)[^.]+$ {
-      add_header Cache-Control "no-cache, must-revalidate";
+      add_header Cache-Control "no-cache, no-store, must-revalidate" always;
       try_files $uri =404;
     }
 
     # any other URL should serve the single page
     location / {
-      add_header Cache-Control "no-cache, must-revalidate";
+      add_header Cache-Control "no-cache, no-store, must-revalidate" always;
       try_files /index.html =404;
     }
   }

--- a/tests/frontend/cache-policy.sh
+++ b/tests/frontend/cache-policy.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FIXTURE_DIR="$(mktemp -d)"
+CONTAINER_NAME="sihsalus-frontend-cache-test-$$"
+
+cleanup() {
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  rm -rf "$FIXTURE_DIR"
+}
+trap cleanup EXIT
+
+chmod 755 "$FIXTURE_DIR"
+for file in \
+  index.html \
+  importmap.json \
+  routes.registry.json \
+  frontend.json \
+  build-info.json \
+  service-worker.js \
+  openmrs-esm-odontologia-app.js \
+  openmrs-esm-odontologia-app.0123456789abcdef.js \
+  esm-odontologia-806-0123456789abcdef.js \
+  plain-runtime.js; do
+  printf '%s\n' "$file" > "$FIXTURE_DIR/$file"
+done
+
+docker run --detach --rm \
+  --name "$CONTAINER_NAME" \
+  --publish 127.0.0.1::80 \
+  --volume "$ROOT_DIR/frontend/nginx.conf:/etc/nginx/nginx.conf:ro" \
+  --volume "$FIXTURE_DIR:/usr/share/nginx/html:ro" \
+  nginx:1.28-alpine >/dev/null
+
+PORT="$(docker port "$CONTAINER_NAME" 80/tcp | sed -E 's/.*:([0-9]+)$/\1/' | head -n 1)"
+BASE_URL="http://127.0.0.1:$PORT"
+
+for _ in $(seq 1 30); do
+  if curl --fail --silent --output /dev/null "$BASE_URL/"; then
+    break
+  fi
+  sleep 0.2
+done
+
+assert_cache_control() {
+  local path="$1"
+  local expected="$2"
+  local headers
+  headers="$(curl --fail --silent --show-error --head "$BASE_URL$path")"
+
+  if ! grep -Fqi "Cache-Control: $expected" <<< "$headers"; then
+    echo "[FAIL] $path did not return Cache-Control: $expected" >&2
+    echo "$headers" >&2
+    exit 1
+  fi
+}
+
+NO_CACHE="no-cache, no-store, must-revalidate"
+IMMUTABLE="public, max-age=31536000, immutable"
+
+assert_cache_control /service-worker.js "$NO_CACHE"
+assert_cache_control /importmap.json "$NO_CACHE"
+assert_cache_control /openmrs-esm-odontologia-app.js "$NO_CACHE"
+assert_cache_control /plain-runtime.js "$NO_CACHE"
+assert_cache_control /openmrs-esm-odontologia-app.0123456789abcdef.js "$IMMUTABLE"
+assert_cache_control /esm-odontologia-806-0123456789abcdef.js "$IMMUTABLE"
+assert_cache_control /patient/example/chart/atencion-odontologica "$NO_CACHE"
+
+echo "[OK] frontend cache policy"

--- a/tests/frontend/cache-policy.sh
+++ b/tests/frontend/cache-policy.sh
@@ -36,12 +36,20 @@ docker run --detach --rm \
 PORT="$(docker port "$CONTAINER_NAME" 80/tcp | sed -E 's/.*:([0-9]+)$/\1/' | head -n 1)"
 BASE_URL="http://127.0.0.1:$PORT"
 
+ready=false
 for _ in $(seq 1 30); do
   if curl --fail --silent --output /dev/null "$BASE_URL/"; then
+    ready=true
     break
   fi
   sleep 0.2
 done
+
+if [ "$ready" != "true" ]; then
+  echo "[FAIL] frontend nginx did not become ready" >&2
+  docker logs "$CONTAINER_NAME" >&2
+  exit 1
+fi
 
 assert_cache_control() {
   local path="$1"


### PR DESCRIPTION
## Problema

El Nginx efectivo del frontend aplica un año de caché a todo JavaScript, incluidos entrypoints estables. Un navegador puede conservar un remote viejo que referencia chunks ya retirados y dejar módulos clínicos en blanco.

## Cambio

- `no-cache, no-store, must-revalidate` para archivos de control, entrypoints y JS/CSS sin hash.
- caché anual `immutable` únicamente para JS/CSS content-addressed, tanto con hash separado por punto como por guion;
- prueba HTTP real contra `nginx:1.28-alpine` para entrypoints, chunks, service worker, import map y fallback SPA;
- ejecución de ese contrato en el gate de CI.

La corrección frontend complementaria es sihsalus/sihsalus-frontend#611. Ambos PR son independientes, pero juntos reparan los navegadores ya afectados y previenen la regresión.
