### PR TITLE
chore: actualizar SIHSALUS content a 1.22.0

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -62,7 +62,7 @@
     <fua.version>1.0.86</fua.version>
     <imaging.version>1.2.8</imaging.version>
     <!-- Content Packages -->
-    <sihsalus-content.version>1.20.0</sihsalus-content.version>
+    <sihsalus-content.version>1.22.0</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
     <reference-demo-content.version>1.8.0-SNAPSHOT</reference-demo-content.version>
   </properties>


### PR DESCRIPTION
## Resultado

Actualiza la distribución para consumir `sihsalus-content 1.22.0`, ya disponible públicamente en Maven Central.

Incluye, entre otros cambios, el privilegio `app:hoja.clinica.resumenConsulta.editar`, la corrección RBAC de admisión y los cambios canónicos de seguros presentes en content/main.

## Cambio

- `sihsalus-content.version`: `1.20.0` → `1.22.0`.

## Validación

- artefacto ZIP `1.22.0`: disponible en Maven Central (`HTTP 200`);
- se delega la compilación y validación a GitHub Actions;
- no se ejecutaron pruebas locales.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->