### PR TITLE
fix: prune stale OpenMRS distribution artifacts

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -38,6 +38,20 @@ RUN cp /openmrs_distro/backend/target/sdk-distro/web/openmrs_core/openmrs.war /o
 # Runtime stays pinned to the exact OpenMRS patch version used in production.
 FROM ${OPENMRS_RUNTIME_IMAGE}
 
+# The pinned OpenMRS runtime quotes the wildcard used to clear distribution
+# directories, so removed modules and metadata survive in the persistent volume.
+# Keep the upstream safety guard while allowing the wildcard to expand.
+RUN sed -i \
+      -e 's|rm -fR "${OMRS_MODULES_DIR:?}/\*"|rm -fR "${OMRS_MODULES_DIR:?}"/*|' \
+      -e 's|rm -fR "${OMRS_OWA_DIR:?}/\*"|rm -fR "${OMRS_OWA_DIR:?}"/*|' \
+      -e 's|rm -fR "${OMRS_CONFIG_DIR:?}/\*"|rm -fR "${OMRS_CONFIG_DIR:?}"/*|' \
+      -e 's|rm -fR "${OMRS_FRONTEND_DIR:?}/\*"|rm -fR "${OMRS_FRONTEND_DIR:?}"/*|' \
+      /openmrs/startup-init.sh && \
+    grep -qF 'rm -fR "${OMRS_MODULES_DIR:?}"/*' /openmrs/startup-init.sh && \
+    grep -qF 'rm -fR "${OMRS_OWA_DIR:?}"/*' /openmrs/startup-init.sh && \
+    grep -qF 'rm -fR "${OMRS_CONFIG_DIR:?}"/*' /openmrs/startup-init.sh && \
+    grep -qF 'rm -fR "${OMRS_FRONTEND_DIR:?}"/*' /openmrs/startup-init.sh
+
 # Do not copy the war if using the correct openmrs-core image version
 COPY --from=dev /openmrs/distribution/openmrs_core/openmrs.war /openmrs/distribution/openmrs_core/
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -64,7 +64,6 @@
     <!-- Content Packages -->
     <sihsalus-content.version>1.23.0</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
-    <reference-demo-content.version>1.8.0-SNAPSHOT</reference-demo-content.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Resumen
- corrige el wildcard entre comillas del runtime OpenMRS para limpiar módulos, OWAs, configuración y frontend antes de copiar la distribución actual
- elimina la propiedad reference-demo-content obsoleta y no utilizada
- conserva reference-content 1.4.0, vigente y usado únicamente por el perfil alternativo no-demo

## Hallazgo en PowerEdge
El volumen conservaba simultáneamente los ZIP OCL de seguros 2026-07-10-01 y 2026-07-17-01. La DB sí reflejaba la versión nueva, pero ambos archivos seguían importables porque startup-init.sh no expandía el glob de limpieza.

El runtime fue depurado con respaldo previo; ahora /openmrs/data/configuration coincide exactamente con /openmrs/distribution/openmrs_config (192/192 archivos).

## Validación
- mvn --batch-mode --file backend/pom.xml validate
- perfil no-demo resuelve reference-content 1.4.0
- parche probado contra la imagen backend actualmente desplegada; bash -n correcto
- bash scripts/validate-compose.sh
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->