### PR TITLE
chore: use SIHSALUS content 1.23.1

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -62,7 +62,7 @@
     <fua.version>1.0.86</fua.version>
     <imaging.version>1.2.8</imaging.version>
     <!-- Content Packages -->
-    <sihsalus-content.version>1.23.0</sihsalus-content.version>
+    <sihsalus-content.version>1.23.1</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
   </properties>
 


### PR DESCRIPTION
## Resumen
- actualiza el paquete de contenido de `1.23.0` a `1.23.1`
- hace reproducible el acceso operativo de Admisión al tablero y entradas de colas
- mantiene fuera de Admisión la administración de colas, salas y purgas

## Validación
- `mvn --batch-mode --update-snapshots --file backend/pom.xml clean package`
- artefacto `1.23.1` disponible en Maven Central
- CI de `sihsalus-content` publicado correctamente

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->