### PR TITLE
chore: use SIHSALUS content 1.23.2

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -62,7 +62,7 @@
     <fua.version>1.0.86</fua.version>
     <imaging.version>1.2.8</imaging.version>
     <!-- Content Packages -->
-    <sihsalus-content.version>1.23.1</sihsalus-content.version>
+    <sihsalus-content.version>1.23.2</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
   </properties>
 


### PR DESCRIPTION
## Resumen
- actualiza el paquete de contenido de `1.23.1` a `1.23.2`
- normaliza el nombre histórico del rol de Admisión antes de sincronizar sus permisos
- evita el error `A role name cannot be edited` en DEV y PowerEdge

## Validación
- `mvn --batch-mode --update-snapshots --file backend/pom.xml clean package`
- artefacto `1.23.2` disponible en Maven Central
- migración probada con referencias y claves foráneas en MariaDB

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->