### PR TITLE
chore: update content package to 1.23.4

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -62,7 +62,7 @@
     <fua.version>1.0.86</fua.version>
     <imaging.version>1.2.8</imaging.version>
     <!-- Content Packages -->
-    <sihsalus-content.version>1.23.3</sihsalus-content.version>
+    <sihsalus-content.version>1.23.4</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
   </properties>
 


### PR DESCRIPTION
## Resumen
- actualiza `sihsalus-content` de `1.23.3` a `1.23.4`
- incorpora la restauración de privilegios técnicos de visita para Admisión

## Verificación previa
- artefacto ZIP `1.23.4` disponible en Maven Central
- content PR sihsalus/sihsalus-content#174 con CI exitoso

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->