### PR TITLE
chore: update content package to 1.23.5

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -62,7 +62,7 @@
     <fua.version>1.0.86</fua.version>
     <imaging.version>1.2.8</imaging.version>
     <!-- Content Packages -->
-    <sihsalus-content.version>1.23.4</sihsalus-content.version>
+    <sihsalus-content.version>1.23.5</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
   </properties>
 


### PR DESCRIPTION
## Resumen
- actualiza `sihsalus-content` de `1.23.4` a `1.23.5`
- incorpora el privilegio de lectura que OpenMRS Core exige para persistir atributos en el POST inicial de una visita de Admisión

## Verificación previa
- content PR sihsalus/sihsalus-content#175 mergeado con CI exitoso
- ZIP `1.23.5` disponible en Maven Central (HTTP 200)
- `mvn --batch-mode --update-snapshots --file backend/pom.xml clean package` exitoso

No cambia versiones de OMOD ni configuración de base de datos fuera del paquete de metadata.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->