### PR TITLE
chore: use sihsalus content 1.23.6

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -62,7 +62,7 @@
     <fua.version>1.0.86</fua.version>
     <imaging.version>1.2.8</imaging.version>
     <!-- Content Packages -->
-    <sihsalus-content.version>1.23.5</sihsalus-content.version>
+    <sihsalus-content.version>1.23.6</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
   </properties>
 


### PR DESCRIPTION
## Resumen
- actualiza `sihsalus-content` de `1.23.5` a `1.23.6`
- habilita la generación del número de turno para el rol `Admision` mediante la dependencia técnica `Get Encounters`

## Verificación
- `1.23.6` está publicado y resoluble en Maven Central
- el content validó CSV, RBAC, rutas cita-consulta-cola y empaquetado Maven
- la integración del content está construyendo el backend SIH Salus con esta versión exacta

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->