### PR TITLE
fix(deploy): pin frontend-only rollout to verified digest

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -33,7 +33,7 @@ jobs:
       digest: ${{ steps.release.outputs.digest }}
       tag: ${{ steps.release.outputs.tag }}
     steps:
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Resolve and verify release
         id: release
@@ -59,8 +59,16 @@ jobs:
 
           if [[ -z "${requested_sha}" ]]; then
             latest_json="$(docker buildx imagetools inspect "${image}:latest" --format '{{json .}}')"
-            requested_sha="$(jq -r '.image.config.Labels["org.opencontainers.image.revision"] // empty' <<<"${latest_json}")"
-            requested_digest="$(jq -r '.manifest.digest // empty' <<<"${latest_json}")"
+            latest_sha="$(jq -r '.image.config.Labels["org.opencontainers.image.revision"] // empty' <<<"${latest_json}")"
+            latest_digest="$(jq -r '.manifest.digest // empty' <<<"${latest_json}")"
+
+            if [[ -n "${requested_digest}" && "${requested_digest}" != "${latest_digest}" ]]; then
+              echo "::error::The requested digest is not the currently promoted latest image."
+              exit 1
+            fi
+
+            requested_sha="${latest_sha}"
+            requested_digest="${latest_digest}"
           fi
 
           if [[ ! "${requested_sha}" =~ ^[0-9a-f]{40}$ ]]; then
@@ -100,7 +108,7 @@ jobs:
       name: development
       url: https://gidis-hsc-dev.inf.pucp.edu.pe/openmrs/spa
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Configure SSH
         env:
@@ -141,7 +149,7 @@ jobs:
       name: quality
       url: https://gidis-hsc-qlty.inf.pucp.edu.pe/openmrs/spa
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Configure SSH
         env:

--- a/compose/core.yml
+++ b/compose/core.yml
@@ -42,7 +42,7 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
       args:
-        FRONTEND_SOURCE_IMAGE: ghcr.io/sihsalus/sihsalus-frontend:${FRONTEND_SOURCE_TAG:-latest}
+        FRONTEND_SOURCE_IMAGE: ${FRONTEND_SOURCE_IMAGE:-ghcr.io/sihsalus/sihsalus-frontend:${FRONTEND_SOURCE_TAG:-latest}}
         SPA_PATH: /openmrs/spa
         API_URL: /openmrs
         SPA_CONFIG_URLS: /openmrs/spa/frontend.json

--- a/docs/operations/deploy-checklist.md
+++ b/docs/operations/deploy-checklist.md
@@ -10,6 +10,11 @@ inmutable, y despliega secuencialmente en DEV y QLTY. DEV funciona como canario:
 si falla, QLTY no se modifica. Un fallo posterior a la actualización restaura
 el tag y contenedor frontend anterior.
 
+Cada servidor consume la imagen fuente mediante su digest `sha256`, reconstruye
+el wrapper runtime y recrea únicamente `frontend` con `--no-deps`. El despliegue
+no descarga, reconstruye ni recrea gateway, backend, bases de datos u otros
+servicios.
+
 El workflow también acepta `repository_dispatch` de tipo `frontend-published` y
 ejecución manual. Producción queda fuera de esta automatización y conserva el
 checklist con aprobación explícita.

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -7,10 +7,17 @@ El script:
 
 1. valida el SHA y digest solicitados;
 2. actualiza el checkout del distro mediante fast-forward;
-3. fija `FRONTEND_SOURCE_TAG` y `FRONTEND_RUNTIME_TAG` al tag inmutable;
+3. fija `FRONTEND_SOURCE_IMAGE` al digest inmutable y conserva el tag SHA como
+   metadato operativo; el runtime local recibe un tag derivado del mismo digest
+   para que un rebuild del mismo commit no destruya la ruta de rollback;
 4. reconstruye el wrapper runtime y recrea solo `frontend`;
 5. verifica salud, imagen y `build-info.json`;
 6. restaura la configuración y el contenedor anterior si falla.
+
+No ejecuta `docker compose pull`, `up`, `restart` ni `build` sobre el stack
+completo. El único pull explícito es la imagen fuente del frontend por digest;
+el build y la recreación están dirigidos exclusivamente al servicio `frontend`
+con `--no-deps`.
 
 La automatización normal vive en `.github/workflows/deploy-frontend.yml`.
 Para una ejecución manual:

--- a/scripts/deploy/deploy-frontend.sh
+++ b/scripts/deploy/deploy-frontend.sh
@@ -9,8 +9,10 @@ fi
 
 TARGET_SHA="$1"
 TARGET_DIGEST="$2"
-TARGET_TAG="sha-${TARGET_SHA}"
-SOURCE_IMAGE="ghcr.io/sihsalus/sihsalus-frontend:${TARGET_TAG}"
+SOURCE_TAG="sha-${TARGET_SHA}"
+RUNTIME_TAG="digest-${TARGET_DIGEST#sha256:}"
+SOURCE_REPOSITORY="ghcr.io/sihsalus/sihsalus-frontend"
+SOURCE_IMAGE="${SOURCE_REPOSITORY}@${TARGET_DIGEST}"
 
 if [[ ! "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]; then
   echo "[deploy-frontend] invalid frontend SHA" >&2
@@ -36,7 +38,13 @@ fi
 
 read_env_value() {
   local key="$1"
-  awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' .env
+  awk -F= -v key="$key" '
+    $1 == key {
+      sub(/^[^=]*=/, "")
+      value = $0
+    }
+    END { print value }
+  ' .env
 }
 
 write_env_value() {
@@ -76,31 +84,46 @@ container_health() {
     2>/dev/null || true
 }
 
+container_image() {
+  docker inspect sihsalus-frontend --format '{{.Config.Image}}' 2>/dev/null || true
+}
+
 CURRENT_SHA="$(deployed_sha || true)"
+CURRENT_SOURCE_IMAGE="$(read_env_value FRONTEND_SOURCE_IMAGE)"
 CURRENT_SOURCE_TAG="$(read_env_value FRONTEND_SOURCE_TAG)"
 CURRENT_RUNTIME_TAG="$(read_env_value FRONTEND_RUNTIME_TAG)"
 CURRENT_HEALTH="$(container_health)"
+CURRENT_IMAGE="$(container_image)"
+RUNTIME_IMAGE_REPOSITORY="$(read_env_value FRONTEND_RUNTIME_IMAGE)"
+RUNTIME_IMAGE_REPOSITORY="${RUNTIME_IMAGE_REPOSITORY:-sihsalus-frontend-runtime}"
+TARGET_RUNTIME_IMAGE="${RUNTIME_IMAGE_REPOSITORY}:${RUNTIME_TAG}"
 
 if [ "$CURRENT_SHA" = "$TARGET_SHA" ] &&
-  [ "$CURRENT_SOURCE_TAG" = "$TARGET_TAG" ] &&
-  [ "$CURRENT_RUNTIME_TAG" = "$TARGET_TAG" ] &&
+  [ "$CURRENT_SOURCE_IMAGE" = "$SOURCE_IMAGE" ] &&
+  [ "$CURRENT_SOURCE_TAG" = "$SOURCE_TAG" ] &&
+  [ "$CURRENT_RUNTIME_TAG" = "$RUNTIME_TAG" ] &&
+  [ "$CURRENT_IMAGE" = "$TARGET_RUNTIME_IMAGE" ] &&
   [ "$CURRENT_HEALTH" = "healthy" ]; then
-  echo "[deploy-frontend] ${TARGET_TAG} is already healthy; nothing to do"
+  echo "[deploy-frontend] ${SOURCE_TAG} at ${TARGET_DIGEST} is already healthy; nothing to do"
   exit 0
 fi
 
 ENV_BACKUP="$(mktemp)"
 cp -p .env "$ENV_BACKUP"
 ROLLBACK_REQUIRED=true
+FRONTEND_RECREATE_ATTEMPTED=false
 
 rollback() {
   local exit_code="${1:-$?}"
-  trap - ERR INT TERM
+  trap - ERR HUP INT TERM
 
   if [ "$ROLLBACK_REQUIRED" = true ]; then
     echo "[deploy-frontend] deployment failed; restoring previous frontend configuration" >&2
     cp -p "$ENV_BACKUP" .env
-    docker compose up -d --no-deps --no-build --force-recreate frontend || true
+    if [ "$FRONTEND_RECREATE_ATTEMPTED" = true ]; then
+      echo "[deploy-frontend] restoring previous frontend container" >&2
+      docker compose up -d --no-deps --no-build --force-recreate frontend || true
+    fi
   fi
 
   rm -f "$ENV_BACKUP"
@@ -108,6 +131,7 @@ rollback() {
 }
 
 trap 'rollback $?' ERR
+trap 'rollback 129' HUP
 trap 'rollback 130' INT
 trap 'rollback 143' TERM
 
@@ -115,11 +139,21 @@ echo "[deploy-frontend] updating distro checkout"
 git fetch origin main
 git merge --ff-only origin/main
 
-echo "[deploy-frontend] pulling immutable source image ${TARGET_TAG}"
+echo "[deploy-frontend] pulling immutable source image ${SOURCE_IMAGE}"
 docker pull "$SOURCE_IMAGE"
 
-write_env_value FRONTEND_SOURCE_TAG "$TARGET_TAG"
-write_env_value FRONTEND_RUNTIME_TAG "$TARGET_TAG"
+SOURCE_SHA="$(
+  docker image inspect "$SOURCE_IMAGE" \
+    --format '{{index .Config.Labels "org.opencontainers.image.revision"}}'
+)"
+if [ "$SOURCE_SHA" != "$TARGET_SHA" ]; then
+  echo "[deploy-frontend] source image revision does not match requested SHA" >&2
+  false
+fi
+
+write_env_value FRONTEND_SOURCE_IMAGE "$SOURCE_IMAGE"
+write_env_value FRONTEND_SOURCE_TAG "$SOURCE_TAG"
+write_env_value FRONTEND_RUNTIME_TAG "$RUNTIME_TAG"
 
 docker compose config --quiet
 
@@ -127,6 +161,7 @@ echo "[deploy-frontend] building runtime wrapper"
 docker compose build --pull frontend
 
 echo "[deploy-frontend] recreating frontend only"
+FRONTEND_RECREATE_ATTEMPTED=true
 docker compose up -d --no-deps --no-build --force-recreate frontend
 
 for _ in $(seq 1 36); do
@@ -155,14 +190,13 @@ if [ "$ACTUAL_SHA" != "$TARGET_SHA" ]; then
 fi
 
 ACTUAL_IMAGE="$(docker inspect sihsalus-frontend --format '{{.Config.Image}}')"
-EXPECTED_IMAGE="sihsalus-frontend-runtime:${TARGET_TAG}"
-if [ "$ACTUAL_IMAGE" != "$EXPECTED_IMAGE" ]; then
-  echo "[deploy-frontend] deployed runtime image is not ${EXPECTED_IMAGE}" >&2
+if [ "$ACTUAL_IMAGE" != "$TARGET_RUNTIME_IMAGE" ]; then
+  echo "[deploy-frontend] deployed runtime image is not ${TARGET_RUNTIME_IMAGE}" >&2
   false
 fi
 
 ROLLBACK_REQUIRED=false
-trap - ERR INT TERM
+trap - ERR HUP INT TERM
 rm -f "$ENV_BACKUP"
 
-echo "[deploy-frontend] deployed ${TARGET_TAG} (${TARGET_DIGEST})"
+echo "[deploy-frontend] deployed ${SOURCE_TAG} from ${SOURCE_IMAGE}"

--- a/tests/frontend/deploy-frontend.sh
+++ b/tests/frontend/deploy-frontend.sh
@@ -8,17 +8,24 @@ trap 'rm -rf "$TEST_ROOT"' EXIT
 
 OLD_SHA='1111111111111111111111111111111111111111'
 TARGET_SHA='2222222222222222222222222222222222222222'
+BAD_SHA='3333333333333333333333333333333333333333'
+OLD_DIGEST='sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
 TARGET_DIGEST='sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+SOURCE_REPOSITORY='ghcr.io/sihsalus/sihsalus-frontend'
+TARGET_SOURCE_IMAGE="${SOURCE_REPOSITORY}@${TARGET_DIGEST}"
+TARGET_RUNTIME_TAG="digest-${TARGET_DIGEST#sha256:}"
 
 make_fixture() {
   local fixture="$1"
   mkdir -p "$fixture/bin" "$fixture/state"
   touch "$fixture/docker-compose.yml"
   cat >"$fixture/.env" <<EOF
+FRONTEND_SOURCE_IMAGE=${SOURCE_REPOSITORY}@${OLD_DIGEST}
 FRONTEND_SOURCE_TAG=sha-${OLD_SHA}
 FRONTEND_RUNTIME_TAG=sha-${OLD_SHA}
 EOF
   printf '%s\n' "$OLD_SHA" >"$fixture/state/deployed_sha"
+  printf '%s\n' "$TARGET_SHA" >"$fixture/state/source_sha"
   printf '%s\n' "healthy" >"$fixture/state/health"
   printf '%s\n' "sihsalus-frontend-runtime:sha-${OLD_SHA}" >"$fixture/state/image"
 
@@ -34,6 +41,13 @@ set -euo pipefail
 printf 'docker %s\n' "$*" >>"${FAKE_STATE_DIR}/commands"
 
 case "${1:-}" in
+  image)
+    if [ "${2:-}" != "inspect" ]; then
+      echo "unexpected docker image command: $*" >&2
+      exit 89
+    fi
+    cat "${FAKE_STATE_DIR}/source_sha"
+    ;;
   exec)
     printf '{\n  "gitSha": "%s"\n}\n' "$(cat "${FAKE_STATE_DIR}/deployed_sha")"
     ;;
@@ -57,7 +71,15 @@ case "${1:-}" in
         ;;
       up)
         runtime_tag="$(awk -F= '$1 == "FRONTEND_RUNTIME_TAG" { print $2 }' .env)"
-        printf '%s\n' "${runtime_tag#sha-}" >"${FAKE_STATE_DIR}/deployed_sha"
+        deployed_sha="${runtime_tag#sha-}"
+        if [ "$runtime_tag" = "${FAKE_TARGET_RUNTIME_TAG}" ]; then
+          deployed_sha="${FAKE_TARGET_SHA}"
+        fi
+        if [ "${FAKE_BAD_DEPLOY_SHA:-false}" = true ] &&
+          [ "$runtime_tag" = "${FAKE_TARGET_RUNTIME_TAG}" ]; then
+          deployed_sha="${FAKE_BAD_SHA}"
+        fi
+        printf '%s\n' "$deployed_sha" >"${FAKE_STATE_DIR}/deployed_sha"
         printf '%s\n' "healthy" >"${FAKE_STATE_DIR}/health"
         printf '%s\n' "sihsalus-frontend-runtime:${runtime_tag}" >"${FAKE_STATE_DIR}/image"
         ;;
@@ -83,6 +105,9 @@ run_deploy() {
     cd "$fixture"
     PATH="$fixture/bin:$PATH" \
       FAKE_STATE_DIR="$fixture/state" \
+      FAKE_TARGET_RUNTIME_TAG="$TARGET_RUNTIME_TAG" \
+      FAKE_TARGET_SHA="$TARGET_SHA" \
+      FAKE_BAD_SHA="$BAD_SHA" \
       "$ROOT/scripts/deploy/deploy-frontend.sh" "$TARGET_SHA" "$TARGET_DIGEST"
   )
 }
@@ -93,6 +118,33 @@ assert_value() {
   local message="$3"
   if [ "$actual" != "$expected" ]; then
     echo "$message: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+assert_frontend_only_mutations() {
+  local commands="$1"
+  local expected_build='docker compose build --pull frontend'
+  local expected_up='docker compose up -d --no-deps --no-build --force-recreate frontend'
+  local expected_pull="docker pull ${TARGET_SOURCE_IMAGE}"
+
+  if grep -Eq '^docker compose (pull|down|stop|restart)( |$)' "$commands"; then
+    echo "deployment attempted a stack-wide or unrelated compose mutation" >&2
+    exit 1
+  fi
+
+  if grep '^docker compose build' "$commands" | grep -Fvx "$expected_build"; then
+    echo "deployment attempted to build a service other than frontend" >&2
+    exit 1
+  fi
+
+  if grep '^docker compose up' "$commands" | grep -Fvx "$expected_up"; then
+    echo "deployment attempted to recreate a service other than frontend" >&2
+    exit 1
+  fi
+
+  if grep '^docker pull' "$commands" | grep -Fvx "$expected_pull"; then
+    echo "deployment pulled an image other than the frontend source digest" >&2
     exit 1
   fi
 }
@@ -125,9 +177,11 @@ fi
 noop_fixture="$TEST_ROOT/noop"
 make_fixture "$noop_fixture"
 sed -i.bak "s/${OLD_SHA}/${TARGET_SHA}/g" "$noop_fixture/.env"
+sed -i.bak "s/${OLD_DIGEST}/${TARGET_DIGEST}/g" "$noop_fixture/.env"
+sed -i.bak "s/FRONTEND_RUNTIME_TAG=sha-${TARGET_SHA}/FRONTEND_RUNTIME_TAG=${TARGET_RUNTIME_TAG}/" "$noop_fixture/.env"
 rm -f "$noop_fixture/.env.bak"
 printf '%s\n' "$TARGET_SHA" >"$noop_fixture/state/deployed_sha"
-printf '%s\n' "sihsalus-frontend-runtime:sha-${TARGET_SHA}" >"$noop_fixture/state/image"
+printf '%s\n' "sihsalus-frontend-runtime:${TARGET_RUNTIME_TAG}" >"$noop_fixture/state/image"
 run_deploy "$noop_fixture"
 if grep -Eq 'docker (pull|compose build|compose up)' "$noop_fixture/state/commands"; then
   echo "idempotent deployment unexpectedly changed the frontend" >&2
@@ -137,14 +191,38 @@ fi
 success_fixture="$TEST_ROOT/success"
 make_fixture "$success_fixture"
 run_deploy "$success_fixture"
+assert_value "$TARGET_SOURCE_IMAGE" \
+  "$(awk -F= '$1 == "FRONTEND_SOURCE_IMAGE" { print $2 }' "$success_fixture/.env")" \
+  "source image digest was not pinned"
 assert_value "sha-${TARGET_SHA}" \
   "$(awk -F= '$1 == "FRONTEND_SOURCE_TAG" { print $2 }' "$success_fixture/.env")" \
   "source tag was not updated"
+assert_value "$TARGET_RUNTIME_TAG" \
+  "$(awk -F= '$1 == "FRONTEND_RUNTIME_TAG" { print $2 }' "$success_fixture/.env")" \
+  "runtime tag was not pinned to the source digest"
 assert_value "$TARGET_SHA" \
   "$(cat "$success_fixture/state/deployed_sha")" \
   "deployed SHA was not updated"
+grep -Fqx "docker pull ${TARGET_SOURCE_IMAGE}" "$success_fixture/state/commands"
+grep -Fqx \
+  "docker image inspect ${TARGET_SOURCE_IMAGE} --format {{index .Config.Labels \"org.opencontainers.image.revision\"}}" \
+  "$success_fixture/state/commands"
 grep -q 'docker compose build --pull frontend' "$success_fixture/state/commands"
 grep -q 'docker compose up -d --no-deps --no-build --force-recreate frontend' "$success_fixture/state/commands"
+assert_frontend_only_mutations "$success_fixture/state/commands"
+
+source_mismatch_fixture="$TEST_ROOT/source-mismatch"
+make_fixture "$source_mismatch_fixture"
+printf '%s\n' "$BAD_SHA" >"$source_mismatch_fixture/state/source_sha"
+if run_deploy "$source_mismatch_fixture"; then
+  echo "deployment should have rejected a digest with a different source revision" >&2
+  exit 1
+fi
+if grep -Eq '^docker compose (build|up)' "$source_mismatch_fixture/state/commands"; then
+  echo "source mismatch unexpectedly built or recreated frontend" >&2
+  exit 1
+fi
+assert_frontend_only_mutations "$source_mismatch_fixture/state/commands"
 
 rollback_fixture="$TEST_ROOT/rollback"
 make_fixture "$rollback_fixture"
@@ -152,6 +230,9 @@ if (
   cd "$rollback_fixture"
   PATH="$rollback_fixture/bin:$PATH" \
     FAKE_STATE_DIR="$rollback_fixture/state" \
+    FAKE_TARGET_RUNTIME_TAG="$TARGET_RUNTIME_TAG" \
+    FAKE_TARGET_SHA="$TARGET_SHA" \
+    FAKE_BAD_SHA="$BAD_SHA" \
     FAKE_FAIL_BUILD=true \
     "$ROOT/scripts/deploy/deploy-frontend.sh" "$TARGET_SHA" "$TARGET_DIGEST"
 ); then
@@ -164,5 +245,49 @@ assert_value "sha-${OLD_SHA}" \
 assert_value "$OLD_SHA" \
   "$(cat "$rollback_fixture/state/deployed_sha")" \
   "rollback did not restore the previous frontend"
+if grep -q '^docker compose up' "$rollback_fixture/state/commands"; then
+  echo "build failure unexpectedly recreated the healthy frontend" >&2
+  exit 1
+fi
+assert_frontend_only_mutations "$rollback_fixture/state/commands"
+
+verification_fixture="$TEST_ROOT/verification-rollback"
+make_fixture "$verification_fixture"
+if (
+  cd "$verification_fixture"
+  PATH="$verification_fixture/bin:$PATH" \
+    FAKE_STATE_DIR="$verification_fixture/state" \
+    FAKE_TARGET_RUNTIME_TAG="$TARGET_RUNTIME_TAG" \
+    FAKE_TARGET_SHA="$TARGET_SHA" \
+    FAKE_BAD_SHA="$BAD_SHA" \
+    FAKE_BAD_DEPLOY_SHA=true \
+    "$ROOT/scripts/deploy/deploy-frontend.sh" "$TARGET_SHA" "$TARGET_DIGEST"
+); then
+  echo "deployment should have failed when runtime verification failed" >&2
+  exit 1
+fi
+assert_value "${SOURCE_REPOSITORY}@${OLD_DIGEST}" \
+  "$(awk -F= '$1 == "FRONTEND_SOURCE_IMAGE" { print $2 }' "$verification_fixture/.env")" \
+  "verification rollback did not restore the source digest"
+assert_value "$OLD_SHA" \
+  "$(cat "$verification_fixture/state/deployed_sha")" \
+  "verification rollback did not restore the previous frontend"
+assert_value "2" \
+  "$(grep -c '^docker compose up -d --no-deps --no-build --force-recreate frontend$' "$verification_fixture/state/commands")" \
+  "verification rollback did not recreate only the new and previous frontend"
+assert_frontend_only_mutations "$verification_fixture/state/commands"
+
+rendered_frontend="$(
+  cd "$ROOT"
+  FRONTEND_SOURCE_IMAGE="$TARGET_SOURCE_IMAGE" \
+    FRONTEND_RUNTIME_TAG="$TARGET_RUNTIME_TAG" \
+    docker compose config --format json
+)"
+assert_value "$TARGET_SOURCE_IMAGE" \
+  "$(jq -r '.services.frontend.build.args.FRONTEND_SOURCE_IMAGE' <<<"$rendered_frontend")" \
+  "Compose did not pass the immutable digest to the frontend build"
+assert_value "sihsalus-frontend-runtime:${TARGET_RUNTIME_TAG}" \
+  "$(jq -r '.services.frontend.image' <<<"$rendered_frontend")" \
+  "Compose did not assign the digest-derived runtime tag"
 
 echo "frontend deployment tests passed"


### PR DESCRIPTION
## Resumen

Endurece el despliegue frontend agregado en #211 para que DEV y QLTY consuman exactamente el digest que pasó Release, sin tocar otros servicios.

- usa `ghcr.io/sihsalus/sihsalus-frontend@sha256:...` como fuente real del build
- valida en el servidor que la etiqueta OCI `org.opencontainers.image.revision` coincide con el SHA solicitado
- asigna al runtime local un tag derivado del digest para preservar rollback aunque se reconstruya el mismo commit
- limita mutaciones a `docker pull <frontend@digest>`, `docker compose build --pull frontend` y `docker compose up --no-deps ... frontend`
- evita recrear el frontend sano si el fallo ocurre antes del primer recreate
- conserva rollback del contenedor anterior cuando falla la verificación posterior
- fija las Actions usadas por el workflow a commits revisados

## Garantía de alcance

No se ejecuta `docker compose pull`, `up`, `build`, `restart`, `stop` ni `down` sobre el stack completo. Gateway, backend, OpenMRS, bases de datos y servicios opcionales no se descargan ni recrean. `--pull` se aplica únicamente al build del wrapper `frontend` y sus imágenes base.

## Validación

- `bash -n scripts/deploy/deploy-frontend.sh tests/frontend/deploy-frontend.sh`
- `./tests/frontend/deploy-frontend.sh`
  - no-op saludable
  - inputs inválidos
  - éxito por digest
  - rechazo SHA/digest inconsistente
  - fallo de build sin recreate
  - rollback después de verificación fallida
  - rechazo explícito de comandos que alcancen otros servicios
  - render real de Compose con fuente por digest
- `./scripts/validate-compose.sh` (todos los modelos e invariantes OK)
- `actionlint 1.7.12`
- resolución real de `latest` = tag SHA = digest `sha256:0879433d...14f7d`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->