### PR TITLE
fix(deploy): prevent frontend runtime registry pulls

### DIFF
--- a/docs/operations/deploy-checklist.md
+++ b/docs/operations/deploy-checklist.md
@@ -11,9 +11,10 @@ si falla, QLTY no se modifica. Un fallo posterior a la actualización restaura
 el tag y contenedor frontend anterior.
 
 Cada servidor consume la imagen fuente mediante su digest `sha256`, reconstruye
-el wrapper runtime y recrea únicamente `frontend` con `--no-deps`. El despliegue
-no descarga, reconstruye ni recrea gateway, backend, bases de datos u otros
-servicios.
+el wrapper runtime y recrea únicamente `frontend` con `--no-deps --pull never`.
+El despliegue no descarga, reconstruye ni recrea gateway, backend, bases de
+datos u otros servicios; el único pull permitido es el digest inmutable de la
+imagen fuente del frontend.
 
 El workflow también acepta `repository_dispatch` de tipo `frontend-published` y
 ejecución manual. Producción queda fuera de esta automatización y conserva el

--- a/scripts/deploy/deploy-frontend.sh
+++ b/scripts/deploy/deploy-frontend.sh
@@ -122,7 +122,7 @@ rollback() {
     cp -p "$ENV_BACKUP" .env
     if [ "$FRONTEND_RECREATE_ATTEMPTED" = true ]; then
       echo "[deploy-frontend] restoring previous frontend container" >&2
-      docker compose up -d --no-deps --no-build --force-recreate frontend || true
+      docker compose up -d --no-deps --no-build --pull never --force-recreate frontend || true
     fi
   fi
 
@@ -162,7 +162,7 @@ docker compose build --pull frontend
 
 echo "[deploy-frontend] recreating frontend only"
 FRONTEND_RECREATE_ATTEMPTED=true
-docker compose up -d --no-deps --no-build --force-recreate frontend
+docker compose up -d --no-deps --no-build --pull never --force-recreate frontend
 
 for _ in $(seq 1 36); do
   health="$(container_health)"

--- a/tests/frontend/deploy-frontend.sh
+++ b/tests/frontend/deploy-frontend.sh
@@ -125,7 +125,7 @@ assert_value() {
 assert_frontend_only_mutations() {
   local commands="$1"
   local expected_build='docker compose build --pull frontend'
-  local expected_up='docker compose up -d --no-deps --no-build --force-recreate frontend'
+  local expected_up='docker compose up -d --no-deps --no-build --pull never --force-recreate frontend'
   local expected_pull="docker pull ${TARGET_SOURCE_IMAGE}"
 
   if grep -Eq '^docker compose (pull|down|stop|restart)( |$)' "$commands"; then
@@ -208,7 +208,7 @@ grep -Fqx \
   "docker image inspect ${TARGET_SOURCE_IMAGE} --format {{index .Config.Labels \"org.opencontainers.image.revision\"}}" \
   "$success_fixture/state/commands"
 grep -q 'docker compose build --pull frontend' "$success_fixture/state/commands"
-grep -q 'docker compose up -d --no-deps --no-build --force-recreate frontend' "$success_fixture/state/commands"
+grep -q 'docker compose up -d --no-deps --no-build --pull never --force-recreate frontend' "$success_fixture/state/commands"
 assert_frontend_only_mutations "$success_fixture/state/commands"
 
 source_mismatch_fixture="$TEST_ROOT/source-mismatch"
@@ -273,7 +273,7 @@ assert_value "$OLD_SHA" \
   "$(cat "$verification_fixture/state/deployed_sha")" \
   "verification rollback did not restore the previous frontend"
 assert_value "2" \
-  "$(grep -c '^docker compose up -d --no-deps --no-build --force-recreate frontend$' "$verification_fixture/state/commands")" \
+  "$(grep -c '^docker compose up -d --no-deps --no-build --pull never --force-recreate frontend$' "$verification_fixture/state/commands")" \
   "verification rollback did not recreate only the new and previous frontend"
 assert_frontend_only_mutations "$verification_fixture/state/commands"
 


### PR DESCRIPTION
## Resumen

- añade --pull never al recreate y rollback exclusivos de frontend
- impide que Compose consulte un registry por la imagen runtime construida localmente
- conserva --no-deps y el único pull explícito del digest fuente inmutable
- actualiza pruebas y documentación del contrato DEV/QLTY

## Validación

- bash -n scripts/deploy/deploy-frontend.sh tests/frontend/deploy-frontend.sh
- ./tests/frontend/deploy-frontend.sh
- ./scripts/validate-compose.sh
- docker compose up --help confirma soporte de --pull
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->