### PR TITLE
fix(deploy): offset scheduled frontend poll

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -2,7 +2,8 @@ name: Deploy Frontend
 
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    # Offset from common five-minute boundaries to reduce scheduler contention.
+    - cron: '3-58/5 * * * *'
   repository_dispatch:
     types: [frontend-published]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- move the five-minute frontend poll away from common clock boundaries
- reduce GitHub Actions schedule contention while preserving the same cadence

## Verification
- `actionlint .github/workflows/deploy-frontend.yml`
- `git diff --check`

The deploy remains DEV -> QLTY, digest-pinned, idempotent, and non-production only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->