### PR TITLE
feat(deploy): accept frontend release tags

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -45,6 +45,7 @@ jobs:
           REQUESTED_SHA: ${{ github.event.client_payload.sha || inputs.sha }}
           REQUESTED_DIGEST: ${{ github.event.client_payload.digest || inputs.digest }}
           RELEASE_TAG: ${{ github.event_name == 'push' && github.ref_name || '' }}
+          REQUIRE_LATEST: ${{ github.event_name == 'push' && 'true' || 'false' }}
         run: |
           set -euo pipefail
 
@@ -98,6 +99,17 @@ jobs:
           if [[ "${immutable_sha}" != "${requested_sha}" ]]; then
             echo "::error::The immutable image revision does not match its tag."
             exit 1
+          fi
+
+          if [[ "${REQUIRE_LATEST}" == "true" ]]; then
+            latest_json="$(docker buildx imagetools inspect "${image}:latest" --format '{{json .}}')"
+            latest_sha="$(jq -r '.image.config.Labels["org.opencontainers.image.revision"] // empty' <<<"${latest_json}")"
+            latest_digest="$(jq -r '.manifest.digest // empty' <<<"${latest_json}")"
+
+            if [[ "${latest_sha}" != "${requested_sha}" || "${latest_digest}" != "${immutable_digest}" ]]; then
+              echo "::error::The release signal is not the currently promoted latest image."
+              exit 1
+            fi
           fi
 
           if [[ -n "${requested_digest}" && "${immutable_digest}" != "${requested_digest}" ]]; then

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,6 +1,9 @@
 name: Deploy Frontend
 
 on:
+  push:
+    tags:
+      - 'frontend-release-*'
   schedule:
     # Offset from common five-minute boundaries to reduce scheduler contention.
     - cron: '3-58/5 * * * *'
@@ -41,12 +44,22 @@ jobs:
         env:
           REQUESTED_SHA: ${{ github.event.client_payload.sha || inputs.sha }}
           REQUESTED_DIGEST: ${{ github.event.client_payload.digest || inputs.digest }}
+          RELEASE_TAG: ${{ github.event_name == 'push' && github.ref_name || '' }}
         run: |
           set -euo pipefail
 
           image='ghcr.io/sihsalus/sihsalus-frontend'
           requested_sha="${REQUESTED_SHA:-}"
           requested_digest="${REQUESTED_DIGEST:-}"
+          release_tag="${RELEASE_TAG:-}"
+
+          if [[ -n "${release_tag}" ]]; then
+            if [[ ! "${release_tag}" =~ ^frontend-release-([0-9a-f]{40})$ ]]; then
+              echo "::error::The frontend release tag is invalid."
+              exit 2
+            fi
+            requested_sha="${BASH_REMATCH[1]}"
+          fi
 
           if [[ -n "${requested_sha}" && ! "${requested_sha}" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::The requested frontend SHA is invalid."

--- a/docs/operations/deploy-checklist.md
+++ b/docs/operations/deploy-checklist.md
@@ -10,7 +10,9 @@ workflow `Deploy Frontend` resuelve y verifica la imagen inmutable y despliega
 secuencialmente en DEV y QLTY. DEV funciona como canario: si falla, QLTY no se
 modifica. Un fallo posterior a la actualización restaura el tag y contenedor
 frontend anterior. Un sondeo de `latest` cada cinco minutos conserva una ruta de
-respaldo si la señal inmediata no llega.
+respaldo si la señal inmediata no llega. La señal solo es aceptada cuando su SHA
+y digest siguen correspondiendo a `latest`, por lo que la deploy key no puede
+seleccionar otra versión.
 
 Cada servidor consume la imagen fuente mediante su digest `sha256`, reconstruye
 el wrapper runtime y recrea únicamente `frontend` con `--no-deps --pull never`.

--- a/docs/operations/deploy-checklist.md
+++ b/docs/operations/deploy-checklist.md
@@ -4,11 +4,13 @@ Usar este checklist para cambios en `main`, despliegues de `qlty`, `staging` o p
 
 ## Frontend automatizado en entornos no productivos
 
-El workflow `Deploy Frontend` consulta cada cinco minutos la imagen `latest`
-promovida por el release de `sihsalus-frontend`, resuelve y verifica su tag
-inmutable, y despliega secuencialmente en DEV y QLTY. DEV funciona como canario:
-si falla, QLTY no se modifica. Un fallo posterior a la actualización restaura
-el tag y contenedor frontend anterior.
+El release de `sihsalus-frontend` publica un tag de señal
+`frontend-release-<SHA>` mediante una deploy key limitada a este repositorio. El
+workflow `Deploy Frontend` resuelve y verifica la imagen inmutable y despliega
+secuencialmente en DEV y QLTY. DEV funciona como canario: si falla, QLTY no se
+modifica. Un fallo posterior a la actualización restaura el tag y contenedor
+frontend anterior. Un sondeo de `latest` cada cinco minutos conserva una ruta de
+respaldo si la señal inmediata no llega.
 
 Cada servidor consume la imagen fuente mediante su digest `sha256`, reconstruye
 el wrapper runtime y recrea únicamente `frontend` con `--no-deps --pull never`.
@@ -17,8 +19,10 @@ datos u otros servicios; el único pull permitido es el digest inmutable de la
 imagen fuente del frontend.
 
 El workflow también acepta `repository_dispatch` de tipo `frontend-published` y
-ejecución manual. Producción queda fuera de esta automatización y conserva el
-checklist con aprobación explícita.
+ejecución manual. La deploy key de señal no contiene credenciales de los
+servidores; esas permanecen exclusivamente en los entornos protegidos del
+distro. Producción queda fuera de esta automatización y conserva el checklist
+con aprobación explícita.
 
 ## Antes del despliegue
 

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -22,9 +22,10 @@ con `--no-deps`.
 La automatización normal vive en `.github/workflows/deploy-frontend.yml`. Una
 release verificada de `sihsalus-frontend` publica el tag de señal
 `frontend-release-<SHA>` en este repositorio mediante una deploy key limitada al
-distro. El workflow valida ese SHA contra la imagen inmutable antes de
-desplegar. El sondeo programado de `latest` permanece como respaldo si falla la
-señal inmediata.
+distro. El workflow exige que ese SHA y su digest correspondan a la imagen
+`latest` promovida y los valida contra la imagen inmutable antes de desplegar.
+El sondeo programado de `latest` permanece como respaldo si falla la señal
+inmediata.
 
 Para una ejecución manual:
 

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -19,7 +19,13 @@ completo. El único pull explícito es la imagen fuente del frontend por digest;
 el build y la recreación están dirigidos exclusivamente al servicio `frontend`
 con `--no-deps`.
 
-La automatización normal vive en `.github/workflows/deploy-frontend.yml`.
+La automatización normal vive en `.github/workflows/deploy-frontend.yml`. Una
+release verificada de `sihsalus-frontend` publica el tag de señal
+`frontend-release-<SHA>` en este repositorio mediante una deploy key limitada al
+distro. El workflow valida ese SHA contra la imagen inmutable antes de
+desplegar. El sondeo programado de `latest` permanece como respaldo si falla la
+señal inmediata.
+
 Para una ejecución manual:
 
 ```bash


### PR DESCRIPTION
## Summary
- trigger non-production frontend deployment from repository-scoped release tags
- validate the exact 40-character frontend SHA before resolving its immutable OCI digest
- retain the scheduled poll, repository dispatch, and manual paths as fallbacks

## Security
- the signal tag carries no server credentials or digest trust
- the deploy workflow independently verifies the image revision and digest
- production remains excluded

## Verification
- `actionlint .github/workflows/deploy-frontend.yml`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->