### PR TITLE
fix(deploy): prune stale frontend images safely

### DIFF
--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -12,12 +12,18 @@ El script:
    para que un rebuild del mismo commit no destruya la ruta de rollback;
 4. reconstruye el wrapper runtime y recrea solo `frontend`;
 5. verifica salud, imagen y `build-info.json`;
-6. restaura la configuración y el contenedor anterior si falla.
+6. restaura la configuración y el contenedor anterior si falla;
+7. solo después de verificar el frontend, elimina imágenes antiguas de los dos
+   repositorios exclusivos del frontend y conserva las imágenes fuente y
+   runtime activas.
 
 No ejecuta `docker compose pull`, `up`, `restart` ni `build` sobre el stack
 completo. El único pull explícito es la imagen fuente del frontend por digest;
 el build y la recreación están dirigidos exclusivamente al servicio `frontend`
-con `--no-deps`.
+con `--no-deps`. La limpieza tampoco usa `docker image prune`: enumera
+únicamente `ghcr.io/sihsalus/sihsalus-frontend` y el repositorio runtime
+configurado en `FRONTEND_RUNTIME_IMAGE`, por lo que no elimina imágenes de
+OpenMRS, base de datos, gateway ni otros servicios.
 
 La automatización normal vive en `.github/workflows/deploy-frontend.yml`. Una
 release verificada de `sihsalus-frontend` publica el tag de señal
@@ -35,5 +41,8 @@ Para una ejecución manual:
   sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
-El comando debe ejecutarse desde la raíz del repositorio y requiere que el
-runtime anterior siga disponible localmente para poder realizar rollback.
+El comando debe ejecutarse desde la raíz del repositorio. Durante una
+actualización, la imagen anterior permanece disponible hasta que terminan la
+verificación y la posibilidad de rollback automático. Una reversión posterior
+a un despliegue exitoso vuelve a descargar por digest y reconstruir el frontend
+anterior.

--- a/scripts/deploy/deploy-frontend.sh
+++ b/scripts/deploy/deploy-frontend.sh
@@ -98,12 +98,45 @@ RUNTIME_IMAGE_REPOSITORY="$(read_env_value FRONTEND_RUNTIME_IMAGE)"
 RUNTIME_IMAGE_REPOSITORY="${RUNTIME_IMAGE_REPOSITORY:-sihsalus-frontend-runtime}"
 TARGET_RUNTIME_IMAGE="${RUNTIME_IMAGE_REPOSITORY}:${RUNTIME_TAG}"
 
+prune_repository_images_except() {
+  local repository="$1"
+  local active_image="$2"
+  local active_image_id
+  local image_id
+
+  if ! active_image_id="$(docker image inspect "$active_image" --format '{{.Id}}' 2>/dev/null)"; then
+    echo "[deploy-frontend] warning: cannot resolve active image ${active_image}; skipping ${repository} cleanup" >&2
+    return 0
+  fi
+
+  while IFS= read -r image_id; do
+    if [ -z "$image_id" ] || [ "$image_id" = "$active_image_id" ]; then
+      continue
+    fi
+
+    if docker image rm "$image_id"; then
+      echo "[deploy-frontend] removed stale frontend image ${image_id}"
+    else
+      echo "[deploy-frontend] warning: could not remove stale frontend image ${image_id}" >&2
+    fi
+  done < <(docker image ls "$repository" --quiet --no-trunc | awk 'NF && !seen[$0]++')
+}
+
+prune_stale_frontend_images() {
+  # Never run a global prune on a shared clinical host. Restrict cleanup to
+  # the two frontend repositories and preserve the exact active source and
+  # runtime images required by the healthy container.
+  prune_repository_images_except "$SOURCE_REPOSITORY" "$SOURCE_IMAGE"
+  prune_repository_images_except "$RUNTIME_IMAGE_REPOSITORY" "$TARGET_RUNTIME_IMAGE"
+}
+
 if [ "$CURRENT_SHA" = "$TARGET_SHA" ] &&
   [ "$CURRENT_SOURCE_IMAGE" = "$SOURCE_IMAGE" ] &&
   [ "$CURRENT_SOURCE_TAG" = "$SOURCE_TAG" ] &&
   [ "$CURRENT_RUNTIME_TAG" = "$RUNTIME_TAG" ] &&
   [ "$CURRENT_IMAGE" = "$TARGET_RUNTIME_IMAGE" ] &&
   [ "$CURRENT_HEALTH" = "healthy" ]; then
+  prune_stale_frontend_images
   echo "[deploy-frontend] ${SOURCE_TAG} at ${TARGET_DIGEST} is already healthy; nothing to do"
   exit 0
 fi
@@ -198,5 +231,7 @@ fi
 ROLLBACK_REQUIRED=false
 trap - ERR HUP INT TERM
 rm -f "$ENV_BACKUP"
+
+prune_stale_frontend_images
 
 echo "[deploy-frontend] deployed ${SOURCE_TAG} from ${SOURCE_IMAGE}"

--- a/tests/frontend/deploy-frontend.sh
+++ b/tests/frontend/deploy-frontend.sh
@@ -14,6 +14,13 @@ TARGET_DIGEST='sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 SOURCE_REPOSITORY='ghcr.io/sihsalus/sihsalus-frontend'
 TARGET_SOURCE_IMAGE="${SOURCE_REPOSITORY}@${TARGET_DIGEST}"
 TARGET_RUNTIME_TAG="digest-${TARGET_DIGEST#sha256:}"
+TARGET_RUNTIME_IMAGE="sihsalus-frontend-runtime:${TARGET_RUNTIME_TAG}"
+TARGET_SOURCE_ID='sha256:target-source-image'
+TARGET_RUNTIME_ID='sha256:target-runtime-image'
+OLD_SOURCE_ID='sha256:old-source-image'
+OLD_RUNTIME_ID='sha256:old-runtime-image'
+STALE_SOURCE_ID='sha256:stale-source-image'
+STALE_RUNTIME_ID='sha256:stale-runtime-image'
 
 make_fixture() {
   local fixture="$1"
@@ -28,6 +35,8 @@ EOF
   printf '%s\n' "$TARGET_SHA" >"$fixture/state/source_sha"
   printf '%s\n' "healthy" >"$fixture/state/health"
   printf '%s\n' "sihsalus-frontend-runtime:sha-${OLD_SHA}" >"$fixture/state/image"
+  printf '%s\n' "$OLD_SOURCE_ID" "$TARGET_SOURCE_ID" "$STALE_SOURCE_ID" >"$fixture/state/source_image_ids"
+  printf '%s\n' "$OLD_RUNTIME_ID" "$TARGET_RUNTIME_ID" "$STALE_RUNTIME_ID" >"$fixture/state/runtime_image_ids"
 
   cat >"$fixture/bin/git" <<'EOF'
 #!/usr/bin/env bash
@@ -42,11 +51,52 @@ printf 'docker %s\n' "$*" >>"${FAKE_STATE_DIR}/commands"
 
 case "${1:-}" in
   image)
-    if [ "${2:-}" != "inspect" ]; then
-      echo "unexpected docker image command: $*" >&2
-      exit 89
-    fi
-    cat "${FAKE_STATE_DIR}/source_sha"
+    case "${2:-}" in
+      inspect)
+        if [[ "$*" == *'org.opencontainers.image.revision'* ]]; then
+          cat "${FAKE_STATE_DIR}/source_sha"
+        elif [[ "$*" == *'{{.Id}}'* ]]; then
+          case "${3:-}" in
+            "${FAKE_TARGET_SOURCE_IMAGE}")
+              printf '%s\n' "${FAKE_TARGET_SOURCE_ID}"
+              ;;
+            "${FAKE_TARGET_RUNTIME_IMAGE}")
+              printf '%s\n' "${FAKE_TARGET_RUNTIME_ID}"
+              ;;
+            *)
+              echo "unexpected image inspection: $*" >&2
+              exit 88
+              ;;
+          esac
+        else
+          echo "unexpected image inspection: $*" >&2
+          exit 88
+        fi
+        ;;
+      ls)
+        case "${3:-}" in
+          "${FAKE_SOURCE_REPOSITORY}")
+            cat "${FAKE_STATE_DIR}/source_image_ids"
+            ;;
+          sihsalus-frontend-runtime)
+            cat "${FAKE_STATE_DIR}/runtime_image_ids"
+            ;;
+          *)
+            echo "unexpected image repository listing: $*" >&2
+            exit 88
+            ;;
+        esac
+        ;;
+      rm)
+        if [ "${FAKE_FAIL_CLEANUP:-false}" = true ]; then
+          exit 73
+        fi
+        ;;
+      *)
+        echo "unexpected docker image command: $*" >&2
+        exit 89
+        ;;
+    esac
     ;;
   exec)
     printf '{\n  "gitSha": "%s"\n}\n' "$(cat "${FAKE_STATE_DIR}/deployed_sha")"
@@ -106,10 +156,54 @@ run_deploy() {
     PATH="$fixture/bin:$PATH" \
       FAKE_STATE_DIR="$fixture/state" \
       FAKE_TARGET_RUNTIME_TAG="$TARGET_RUNTIME_TAG" \
+      FAKE_TARGET_RUNTIME_IMAGE="$TARGET_RUNTIME_IMAGE" \
+      FAKE_TARGET_SOURCE_IMAGE="$TARGET_SOURCE_IMAGE" \
+      FAKE_TARGET_RUNTIME_ID="$TARGET_RUNTIME_ID" \
+      FAKE_TARGET_SOURCE_ID="$TARGET_SOURCE_ID" \
+      FAKE_SOURCE_REPOSITORY="$SOURCE_REPOSITORY" \
       FAKE_TARGET_SHA="$TARGET_SHA" \
       FAKE_BAD_SHA="$BAD_SHA" \
       "$ROOT/scripts/deploy/deploy-frontend.sh" "$TARGET_SHA" "$TARGET_DIGEST"
   )
+}
+
+assert_scoped_image_cleanup() {
+  local commands="$1"
+
+  grep -Fqx "docker image ls ${SOURCE_REPOSITORY} --quiet --no-trunc" "$commands"
+  grep -Fqx "docker image ls sihsalus-frontend-runtime --quiet --no-trunc" "$commands"
+
+  grep -Fqx "docker image rm ${OLD_SOURCE_ID}" "$commands"
+  grep -Fqx "docker image rm ${STALE_SOURCE_ID}" "$commands"
+  grep -Fqx "docker image rm ${OLD_RUNTIME_ID}" "$commands"
+  grep -Fqx "docker image rm ${STALE_RUNTIME_ID}" "$commands"
+
+  if grep -Fqx "docker image rm ${TARGET_SOURCE_ID}" "$commands" ||
+    grep -Fqx "docker image rm ${TARGET_RUNTIME_ID}" "$commands"; then
+    echo "cleanup attempted to remove an active frontend image" >&2
+    exit 1
+  fi
+
+  if grep -Eq '^docker image prune( |$)' "$commands"; then
+    echo "cleanup attempted a global image prune" >&2
+    exit 1
+  fi
+
+  if grep '^docker image ls ' "$commands" |
+    grep -Fvx "docker image ls ${SOURCE_REPOSITORY} --quiet --no-trunc" |
+    grep -Fvx "docker image ls sihsalus-frontend-runtime --quiet --no-trunc"; then
+    echo "cleanup enumerated images outside the frontend repositories" >&2
+    exit 1
+  fi
+
+  if grep '^docker image rm ' "$commands" |
+    grep -Fvx "docker image rm ${OLD_SOURCE_ID}" |
+    grep -Fvx "docker image rm ${STALE_SOURCE_ID}" |
+    grep -Fvx "docker image rm ${OLD_RUNTIME_ID}" |
+    grep -Fvx "docker image rm ${STALE_RUNTIME_ID}"; then
+    echo "cleanup attempted to remove an unexpected image" >&2
+    exit 1
+  fi
 }
 
 assert_value() {
@@ -187,6 +281,7 @@ if grep -Eq 'docker (pull|compose build|compose up)' "$noop_fixture/state/comman
   echo "idempotent deployment unexpectedly changed the frontend" >&2
   exit 1
 fi
+assert_scoped_image_cleanup "$noop_fixture/state/commands"
 
 success_fixture="$TEST_ROOT/success"
 make_fixture "$success_fixture"
@@ -210,6 +305,32 @@ grep -Fqx \
 grep -q 'docker compose build --pull frontend' "$success_fixture/state/commands"
 grep -q 'docker compose up -d --no-deps --no-build --pull never --force-recreate frontend' "$success_fixture/state/commands"
 assert_frontend_only_mutations "$success_fixture/state/commands"
+assert_scoped_image_cleanup "$success_fixture/state/commands"
+
+cleanup_warning_fixture="$TEST_ROOT/cleanup-warning"
+make_fixture "$cleanup_warning_fixture"
+if ! (
+  cd "$cleanup_warning_fixture"
+  PATH="$cleanup_warning_fixture/bin:$PATH" \
+    FAKE_STATE_DIR="$cleanup_warning_fixture/state" \
+    FAKE_TARGET_RUNTIME_TAG="$TARGET_RUNTIME_TAG" \
+    FAKE_TARGET_RUNTIME_IMAGE="$TARGET_RUNTIME_IMAGE" \
+    FAKE_TARGET_SOURCE_IMAGE="$TARGET_SOURCE_IMAGE" \
+    FAKE_TARGET_RUNTIME_ID="$TARGET_RUNTIME_ID" \
+    FAKE_TARGET_SOURCE_ID="$TARGET_SOURCE_ID" \
+    FAKE_SOURCE_REPOSITORY="$SOURCE_REPOSITORY" \
+    FAKE_TARGET_SHA="$TARGET_SHA" \
+    FAKE_BAD_SHA="$BAD_SHA" \
+    FAKE_FAIL_CLEANUP=true \
+    "$ROOT/scripts/deploy/deploy-frontend.sh" "$TARGET_SHA" "$TARGET_DIGEST"
+); then
+  echo "best-effort cleanup should not invalidate a verified deployment" >&2
+  exit 1
+fi
+assert_value "$TARGET_SHA" \
+  "$(cat "$cleanup_warning_fixture/state/deployed_sha")" \
+  "cleanup warning invalidated the healthy frontend"
+assert_scoped_image_cleanup "$cleanup_warning_fixture/state/commands"
 
 source_mismatch_fixture="$TEST_ROOT/source-mismatch"
 make_fixture "$source_mismatch_fixture"
@@ -230,10 +351,15 @@ if (
   cd "$rollback_fixture"
   PATH="$rollback_fixture/bin:$PATH" \
     FAKE_STATE_DIR="$rollback_fixture/state" \
-    FAKE_TARGET_RUNTIME_TAG="$TARGET_RUNTIME_TAG" \
-    FAKE_TARGET_SHA="$TARGET_SHA" \
-    FAKE_BAD_SHA="$BAD_SHA" \
-    FAKE_FAIL_BUILD=true \
+      FAKE_TARGET_RUNTIME_TAG="$TARGET_RUNTIME_TAG" \
+      FAKE_TARGET_RUNTIME_IMAGE="$TARGET_RUNTIME_IMAGE" \
+      FAKE_TARGET_SOURCE_IMAGE="$TARGET_SOURCE_IMAGE" \
+      FAKE_TARGET_RUNTIME_ID="$TARGET_RUNTIME_ID" \
+      FAKE_TARGET_SOURCE_ID="$TARGET_SOURCE_ID" \
+      FAKE_SOURCE_REPOSITORY="$SOURCE_REPOSITORY" \
+      FAKE_TARGET_SHA="$TARGET_SHA" \
+      FAKE_BAD_SHA="$BAD_SHA" \
+      FAKE_FAIL_BUILD=true \
     "$ROOT/scripts/deploy/deploy-frontend.sh" "$TARGET_SHA" "$TARGET_DIGEST"
 ); then
   echo "deployment should have failed when the runtime build failed" >&2
@@ -257,10 +383,15 @@ if (
   cd "$verification_fixture"
   PATH="$verification_fixture/bin:$PATH" \
     FAKE_STATE_DIR="$verification_fixture/state" \
-    FAKE_TARGET_RUNTIME_TAG="$TARGET_RUNTIME_TAG" \
-    FAKE_TARGET_SHA="$TARGET_SHA" \
-    FAKE_BAD_SHA="$BAD_SHA" \
-    FAKE_BAD_DEPLOY_SHA=true \
+      FAKE_TARGET_RUNTIME_TAG="$TARGET_RUNTIME_TAG" \
+      FAKE_TARGET_RUNTIME_IMAGE="$TARGET_RUNTIME_IMAGE" \
+      FAKE_TARGET_SOURCE_IMAGE="$TARGET_SOURCE_IMAGE" \
+      FAKE_TARGET_RUNTIME_ID="$TARGET_RUNTIME_ID" \
+      FAKE_TARGET_SOURCE_ID="$TARGET_SOURCE_ID" \
+      FAKE_SOURCE_REPOSITORY="$SOURCE_REPOSITORY" \
+      FAKE_TARGET_SHA="$TARGET_SHA" \
+      FAKE_BAD_SHA="$BAD_SHA" \
+      FAKE_BAD_DEPLOY_SHA=true \
     "$ROOT/scripts/deploy/deploy-frontend.sh" "$TARGET_SHA" "$TARGET_DIGEST"
 ); then
   echo "deployment should have failed when runtime verification failed" >&2


### PR DESCRIPTION
## Resumen

- elimina imágenes antiguas únicamente de los repositorios fuente y runtime del frontend
- conserva por ID las imágenes activas verificadas
- ejecuta la limpieza después de salud/SHA/imagen, también en despliegues idempotentes
- evita deliberadamente cualquier `docker image prune` global
- trata fallos de limpieza como advertencia para no revertir un frontend sano

## Validación

- `bash -n scripts/deploy/deploy-frontend.sh`
- `bash -n tests/frontend/deploy-frontend.sh`
- `./tests/frontend/deploy-frontend.sh`
- casos de no-op, éxito, rollback, SHA incorrecto, limpieza acotada y fallo no fatal de limpieza

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->