### PR TITLE
fix(security): disallow inline SPA scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Test frontend bootstrap configuration
+        run: node --test frontend/patch-config-urls.test.js
+
       - name: Test frontend cache policy
         run: ./tests/frontend/cache-policy.sh
 

--- a/compose/core.yml
+++ b/compose/core.yml
@@ -50,7 +50,9 @@ services:
         STRIP_SOURCE_MAPS: ${STRIP_SOURCE_MAPS:-true}
     restart: "unless-stopped"
     healthcheck:
-      test: [ "CMD-SHELL", "wget -q -O - http://127.0.0.1/ | grep -q 'initializeSpa'" ]
+      # El shell actual externaliza initializeSpa para cumplir CSP. El fallback
+      # al index conserva la capacidad de rollback a una imagen anterior.
+      test: [ "CMD-SHELL", "(wget -q -O - http://127.0.0.1/sihsalus-spa-bootstrap.js | grep -q 'initializeSpa') || (wget -q -O - http://127.0.0.1/ | grep -q 'initializeSpa')" ]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -18,7 +18,7 @@ El frontend es una Single Page Application (SPA) moderna construida con React y 
 frontend/
 ├── Dockerfile         # Construye la imagen runtime versionada
 ├── nginx.conf         # Configuración Nginx para SPA
-├── patch-config-urls.js # Adapta SPA_CONFIG_URLS al index.html
+├── patch-config-urls.js # Valida el bootstrap actual y adapta shells heredados
 └── frontend-keycloak.json
 ```
 
@@ -36,7 +36,7 @@ Imagen: `${FRONTEND_RUNTIME_IMAGE:-sihsalus-frontend-runtime}:${FRONTEND_RUNTIME
 
 **Puertos**: 80 (interno, accesible solo desde gateway)
 
-**Health check**: verifica que el HTML servido contenga `initializeSpa`, no solo que Nginx responda.
+**Health check**: verifica `initializeSpa` en el bootstrap externo. Mantiene un fallback al HTML para que un rollback a una imagen heredada siga siendo posible.
 
 ---
 
@@ -148,7 +148,9 @@ FRONTEND_RUNTIME_TAG=tag-anterior docker compose up -d frontend gateway
    ```
 2. Revisa que la imagen tenga el shell correcto:
    ```bash
-   docker compose exec frontend wget -q -O - http://127.0.0.1/ | grep initializeSpa
+   docker compose exec frontend \
+     wget -q -O - http://127.0.0.1/sihsalus-spa-bootstrap.js |
+     grep initializeSpa
    ```
 3. Revisa logs del gateway:
    ```bash

--- a/frontend/patch-config-urls.js
+++ b/frontend/patch-config-urls.js
@@ -1,41 +1,124 @@
 const fs = require('fs');
 const path = require('path');
 
-const outDir = process.env.SPA_OUTPUT_DIR || '/spa';
-const indexPath = path.join(outDir, 'index.html');
-const rawConfigUrls = (process.env.SPA_CONFIG_URLS || '').trim();
+const CONFIG_URLS_PATTERN = /configUrls:\s*(\[[^\]]*\])/g;
+const EXTERNAL_BOOTSTRAP_FILE = 'sihsalus-spa-bootstrap.js';
 
-if (!rawConfigUrls) {
-  console.error('[patch-config-urls] SPA_CONFIG_URLS is required');
-  process.exit(1);
+function parseConfigUrls(rawConfigUrls) {
+  const normalized = rawConfigUrls.trim();
+  if (!normalized) {
+    throw new Error('SPA_CONFIG_URLS is required');
+  }
+
+  const configUrls = Array.from(
+    new Set(
+      normalized
+        .split(',')
+        .map((url) => url.trim())
+        .filter(Boolean),
+    ),
+  );
+
+  if (configUrls.length === 0) {
+    throw new Error('SPA_CONFIG_URLS did not contain any usable config URL');
+  }
+
+  return configUrls;
 }
 
-if (!fs.existsSync(indexPath)) {
-  console.error(`[patch-config-urls] ${indexPath} not found`);
-  process.exit(1);
+function findSingleInitializer(source, targetPath) {
+  const matches = [...source.matchAll(CONFIG_URLS_PATTERN)];
+  if (matches.length !== 1) {
+    throw new Error(
+      `expected exactly one configUrls initializer in ${targetPath}, found ${matches.length}`,
+    );
+  }
+
+  return matches[0];
 }
 
-const configUrls = Array.from(new Set(
-  rawConfigUrls
-    .split(',')
-    .map((url) => url.trim())
-    .filter(Boolean)
-));
+function reconcileConfigUrls(outDir, rawConfigUrls) {
+  const configUrls = parseConfigUrls(rawConfigUrls);
+  const indexPath = path.join(outDir, 'index.html');
+  const bootstrapPath = path.join(outDir, EXTERNAL_BOOTSTRAP_FILE);
 
-if (configUrls.length === 0) {
-  console.error('[patch-config-urls] SPA_CONFIG_URLS did not contain any usable config URL');
-  process.exit(1);
+  if (!fs.existsSync(indexPath)) {
+    throw new Error(`${indexPath} not found`);
+  }
+
+  if (fs.existsSync(bootstrapPath)) {
+    const bootstrap = fs.readFileSync(bootstrapPath, 'utf8');
+    const initializer = findSingleInitializer(bootstrap, bootstrapPath);
+    let assembledConfigUrls;
+
+    try {
+      assembledConfigUrls = JSON.parse(initializer[1]);
+    } catch (error) {
+      throw new Error(`configUrls initializer in ${bootstrapPath} is not a JSON array`, {
+        cause: error,
+      });
+    }
+
+    if (
+      !Array.isArray(assembledConfigUrls) ||
+      assembledConfigUrls.some((url) => typeof url !== 'string') ||
+      JSON.stringify(assembledConfigUrls) !== JSON.stringify(configUrls)
+    ) {
+      throw new Error(
+        `configUrls in ${bootstrapPath} does not match SPA_CONFIG_URLS; rebuild with the requested configuration`,
+      );
+    }
+
+    return {
+      configUrls,
+      mode: 'validated-external-bootstrap',
+      targetPath: bootstrapPath,
+    };
+  }
+
+  const html = fs.readFileSync(indexPath, 'utf8');
+  const initializer = findSingleInitializer(html, indexPath);
+  const replacement = `configUrls: ${JSON.stringify(configUrls)}`;
+  const nextHtml =
+    html.slice(0, initializer.index) +
+    replacement +
+    html.slice(initializer.index + initializer[0].length);
+
+  fs.writeFileSync(indexPath, nextHtml);
+  return {
+    configUrls,
+    mode: 'patched-legacy-index',
+    targetPath: indexPath,
+  };
 }
 
-const replacement = `configUrls: ${JSON.stringify(configUrls)}`;
-const html = fs.readFileSync(indexPath, 'utf8');
-const configUrlsPattern = /configUrls:\s*\[[^\]]*\]/;
+function main() {
+  const outDir = process.env.SPA_OUTPUT_DIR || '/spa';
+  const rawConfigUrls = process.env.SPA_CONFIG_URLS || '';
+  const result = reconcileConfigUrls(outDir, rawConfigUrls);
 
-if (!configUrlsPattern.test(html)) {
-  console.error('[patch-config-urls] configUrls initializer not found in index.html');
-  process.exit(1);
+  if (result.mode === 'validated-external-bootstrap') {
+    console.log(
+      `[patch-config-urls] validated configUrls in ${result.targetPath}: ${JSON.stringify(result.configUrls)}`,
+    );
+  } else {
+    console.log(
+      `[patch-config-urls] patched configUrls in ${result.targetPath}: ${JSON.stringify(result.configUrls)}`,
+    );
+  }
 }
 
-const nextHtml = html.replace(configUrlsPattern, replacement);
-fs.writeFileSync(indexPath, nextHtml);
-console.log(`[patch-config-urls] ${replacement}`);
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`[patch-config-urls] ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  EXTERNAL_BOOTSTRAP_FILE,
+  parseConfigUrls,
+  reconcileConfigUrls,
+};

--- a/frontend/patch-config-urls.test.js
+++ b/frontend/patch-config-urls.test.js
@@ -1,0 +1,96 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  EXTERNAL_BOOTSTRAP_FILE,
+  parseConfigUrls,
+  reconcileConfigUrls,
+} = require('./patch-config-urls');
+
+function makeOutputDirectory() {
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sihsalus-spa-config-'));
+  fs.writeFileSync(path.join(outDir, 'index.html'), '<!doctype html><html></html>\n');
+  return outDir;
+}
+
+test('normalizes and deduplicates SPA_CONFIG_URLS', () => {
+  assert.deepEqual(
+    parseConfigUrls(' /openmrs/spa/frontend.json, /openmrs/spa/oauth.json, /openmrs/spa/frontend.json '),
+    ['/openmrs/spa/frontend.json', '/openmrs/spa/oauth.json'],
+  );
+});
+
+test('validates an external bootstrap without rewriting the revisioned artifact', (t) => {
+  const outDir = makeOutputDirectory();
+  t.after(() => fs.rmSync(outDir, { recursive: true, force: true }));
+
+  const bootstrapPath = path.join(outDir, EXTERNAL_BOOTSTRAP_FILE);
+  const source =
+    'initializeSpa({\n  apiUrl: "/openmrs",\n  configUrls: ["/openmrs/spa/frontend.json"],\n});\n';
+  fs.writeFileSync(bootstrapPath, source);
+
+  const result = reconcileConfigUrls(outDir, '/openmrs/spa/frontend.json');
+
+  assert.equal(result.mode, 'validated-external-bootstrap');
+  assert.equal(result.targetPath, bootstrapPath);
+  assert.equal(fs.readFileSync(bootstrapPath, 'utf8'), source);
+});
+
+test('rejects an external bootstrap assembled with different config URLs', (t) => {
+  const outDir = makeOutputDirectory();
+  t.after(() => fs.rmSync(outDir, { recursive: true, force: true }));
+
+  fs.writeFileSync(
+    path.join(outDir, EXTERNAL_BOOTSTRAP_FILE),
+    'initializeSpa({ configUrls: ["/unexpected.json"] });\n',
+  );
+
+  assert.throws(
+    () => reconcileConfigUrls(outDir, '/openmrs/spa/frontend.json'),
+    /does not match SPA_CONFIG_URLS/,
+  );
+});
+
+test('patches the inline initializer for a legacy app shell', (t) => {
+  const outDir = makeOutputDirectory();
+  t.after(() => fs.rmSync(outDir, { recursive: true, force: true }));
+
+  const indexPath = path.join(outDir, 'index.html');
+  fs.writeFileSync(
+    indexPath,
+    '<script>initializeSpa({ configUrls: ["$SPA_CONFIG_URLS"] });</script>\n',
+  );
+
+  const result = reconcileConfigUrls(
+    outDir,
+    '/openmrs/spa/frontend.json, /openmrs/spa/frontend-keycloak.json',
+  );
+
+  assert.equal(result.mode, 'patched-legacy-index');
+  assert.match(
+    fs.readFileSync(indexPath, 'utf8'),
+    /configUrls: \["\/openmrs\/spa\/frontend\.json","\/openmrs\/spa\/frontend-keycloak\.json"\]/,
+  );
+});
+
+test('rejects ambiguous or missing config initializers', (t) => {
+  const outDir = makeOutputDirectory();
+  t.after(() => fs.rmSync(outDir, { recursive: true, force: true }));
+
+  assert.throws(
+    () => reconcileConfigUrls(outDir, '/openmrs/spa/frontend.json'),
+    /expected exactly one configUrls initializer.*found 0/,
+  );
+
+  fs.writeFileSync(
+    path.join(outDir, EXTERNAL_BOOTSTRAP_FILE),
+    'const first = { configUrls: ["/one.json"] }; const second = { configUrls: ["/two.json"] };\n',
+  );
+  assert.throws(
+    () => reconcileConfigUrls(outDir, '/openmrs/spa/frontend.json'),
+    /expected exactly one configUrls initializer.*found 2/,
+  );
+});

--- a/gateway/default-ssl.conf.template
+++ b/gateway/default-ssl.conf.template
@@ -2,7 +2,9 @@ map $request_uri $csp_header {
   # Dyaku/FHIR browser access is scoped to the O3 SPA. Imaging and legacy
   # surfaces must not inherit external FHIR connectivity by default.
   default "default-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self'; base-uri 'self'; font-src 'self'; img-src 'self' data:; object-src 'none'; frame-ancestors 'self' ${FRAME_ANCESTORS};";
-  "~^/openmrs/spa/" "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://dyaku.minsa.gob.pe; base-uri 'self'; font-src 'self'; img-src 'self' data:; object-src 'none'; frame-ancestors 'self' ${FRAME_ANCESTORS};";
+  # The assembled SPA externalizes all executable startup code. Inline styles
+  # remain temporarily required by Carbon and React component style props.
+  "~^/openmrs/spa/" "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://dyaku.minsa.gob.pe; base-uri 'self'; font-src 'self'; img-src 'self' data:; object-src 'none'; frame-ancestors 'self' ${FRAME_ANCESTORS};";
   "~^/imaging/" "default-src 'self' blob:; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self'; worker-src 'self' blob:; base-uri 'self'; object-src 'none'; frame-ancestors 'self' ${FRAME_ANCESTORS};";
   # Legacy OpenMRS pages still depend on inline scripts and eval-like behavior.
   "~^/openmrs/(?:admin|dictionary|module|patientDashboard.form|initialsetup)(?:/|$)" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self'; frame-ancestors 'self';";

--- a/gateway/default.conf.template
+++ b/gateway/default.conf.template
@@ -2,7 +2,9 @@ map $request_uri $csp_header {
   # Dyaku/FHIR browser access is scoped to the O3 SPA. Imaging and legacy
   # surfaces must not inherit external FHIR connectivity by default.
   default "default-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self'; base-uri 'self'; font-src 'self'; img-src 'self' data:; object-src 'none'; frame-ancestors 'self' ${FRAME_ANCESTORS};";
-  "~^/openmrs/spa/" "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://dyaku.minsa.gob.pe; base-uri 'self'; font-src 'self'; img-src 'self' data:; object-src 'none'; frame-ancestors 'self' ${FRAME_ANCESTORS};";
+  # The assembled SPA externalizes all executable startup code. Inline styles
+  # remain temporarily required by Carbon and React component style props.
+  "~^/openmrs/spa/" "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://dyaku.minsa.gob.pe; base-uri 'self'; font-src 'self'; img-src 'self' data:; object-src 'none'; frame-ancestors 'self' ${FRAME_ANCESTORS};";
   "~^/imaging/" "default-src 'self' blob:; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self'; worker-src 'self' blob:; base-uri 'self'; object-src 'none'; frame-ancestors 'self' ${FRAME_ANCESTORS};";
   # Legacy OpenMRS pages still depend on inline scripts and eval-like behavior.
   "~^/openmrs/(?:admin|dictionary|module|patientDashboard.form|initialsetup)(?:/|$)" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self'; frame-ancestors 'self';";

--- a/scripts/validate-compose.sh
+++ b/scripts/validate-compose.sh
@@ -27,8 +27,17 @@ for gateway_template in gateway/default.conf.template gateway/default-ssl.conf.t
     echo "[FAIL] $gateway_template must not discard the startup response body" >&2
     exit 1
   fi
+
+  spa_csp="$(grep -F '"~^/openmrs/spa/"' "$gateway_template")"
+  spa_script_policy="${spa_csp#*script-src }"
+  spa_script_policy="${spa_script_policy%%;*}"
+  if [ "$spa_script_policy" != "'self'" ]; then
+    echo "[FAIL] $gateway_template must not allow inline or cross-origin SPA scripts" >&2
+    exit 1
+  fi
 done
 echo "[OK] gateway health routes use dynamic Docker DNS and valid startup framing"
+echo "[OK] SPA CSP permits only same-origin external scripts"
 
 if [ "$#" -gt 1 ]; then
   echo "Usage: $0 [evidence-directory]" >&2


### PR DESCRIPTION
## Resultado

- elimina `unsafe-inline` de `script-src` exclusivamente para `/openmrs/spa/`
- conserva temporalmente estilos inline requeridos por Carbon/React
- mantiene las excepciones separadas de OpenMRS legacy e imaging
- añade un invariante que impide reintroducir scripts inline o cross-origin en la SPA

## Evidencia local

- `bash -n scripts/validate-compose.sh`: aprobado
- `scripts/validate-compose.sh`: core y todos los perfiles Compose aprobados, incluidos SSL, Keycloak, imaging, FUA y seed

## Orden de entrega

Depende del artefacto frontend de sihsalus/sihsalus-frontend#685, que externaliza el bootstrap y la UI de error. Fusionar/aplicar este gateway únicamente después de que ese release frontend esté disponible.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->