### PR TITLE
feat(deploy): add safe full non-production redeploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Test frontend deployment and rollback
         run: ./tests/frontend/deploy-frontend.sh
 
+      - name: Validate full environment redeploy policy
+        run: ./tests/deploy/redeploy-environment-policy.sh
+
       - name: Validate models and invariants
         run: ./scripts/validate-compose.sh compose-validation
 

--- a/.github/workflows/redeploy-non-production.yml
+++ b/.github/workflows/redeploy-non-production.yml
@@ -1,0 +1,141 @@
+name: Redeploy Non-Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_full_redeploy:
+        description: Recreate every active service in DEV and QLTY while preserving volumes
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: redeploy-non-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-dev:
+    name: Clean redeploy DEV
+    if: inputs.confirm_full_redeploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment:
+      name: development
+      url: https://gidis-hsc-dev.inf.pucp.edu.pe/openmrs/spa
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate redeploy policy
+        run: ./tests/deploy/redeploy-environment-policy.sh
+
+      - name: Configure SSH
+        env:
+          DEPLOY_KEY: ${{ secrets.SSH_PRIVATE_KEY_DEV }}
+          KNOWN_HOSTS: ${{ vars.SSH_KNOWN_HOSTS_DEV }}
+        run: |
+          set -euo pipefail
+          install -d -m 700 "${HOME}/.ssh"
+          printf '%s\n' "${DEPLOY_KEY}" >"${HOME}/.ssh/deploy_key"
+          printf '%s\n' "${KNOWN_HOSTS}" >"${HOME}/.ssh/known_hosts"
+          chmod 600 "${HOME}/.ssh/deploy_key" "${HOME}/.ssh/known_hosts"
+          ssh-keygen -y -f "${HOME}/.ssh/deploy_key" >/dev/null
+
+      - name: Redeploy every active service
+        run: |
+          ssh \
+            -i "${HOME}/.ssh/deploy_key" \
+            -o BatchMode=yes \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=15 \
+            u.hsc.dev@200.16.7.137 \
+            "cd /home/u.hsc.dev/sihsalus && bash -s" \
+            <scripts/deploy/redeploy-environment.sh
+
+      - name: Verify DEV externally
+        run: |
+          set -euo pipefail
+          base='https://gidis-hsc-dev.inf.pucp.edu.pe'
+          curl --insecure --fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 5 \
+            "${base}/health" >/dev/null
+          curl --insecure --fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 5 \
+            "${base}/ready" >/dev/null
+          curl --insecure --fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 5 \
+            "${base}/openmrs/health/started" >/dev/null
+          curl --insecure --fail --silent --show-error \
+            "${base}/openmrs/spa/build-info.json"
+          curl --insecure --fail --silent --show-error \
+            "${base}/openmrs/spa/sihsalus-spa-bootstrap.js" |
+            grep -q 'initializeSpa'
+          csp="$(curl --insecure --fail --silent --show-error --head "${base}/openmrs/spa/" |
+            awk 'BEGIN { IGNORECASE=1 } /^content-security-policy:/ { sub(/\r$/, ""); print; exit }')"
+          grep -Fq "script-src 'self';" <<<"${csp}"
+          if grep -Fq "script-src 'self' 'unsafe-inline'" <<<"${csp}"; then
+            echo "DEV still permits inline SPA scripts" >&2
+            exit 1
+          fi
+
+  deploy-qlty:
+    name: Clean redeploy QLTY
+    if: inputs.confirm_full_redeploy
+    needs: deploy-dev
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment:
+      name: quality
+      url: https://gidis-hsc-qlty.inf.pucp.edu.pe/openmrs/spa
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate redeploy policy
+        run: ./tests/deploy/redeploy-environment-policy.sh
+
+      - name: Configure SSH
+        env:
+          DEPLOY_KEY: ${{ secrets.SSH_PRIVATE_KEY_QLTY }}
+          KNOWN_HOSTS: ${{ vars.SSH_KNOWN_HOSTS_QLTY }}
+        run: |
+          set -euo pipefail
+          install -d -m 700 "${HOME}/.ssh"
+          printf '%s\n' "${DEPLOY_KEY}" >"${HOME}/.ssh/deploy_key"
+          printf '%s\n' "${KNOWN_HOSTS}" >"${HOME}/.ssh/known_hosts"
+          chmod 600 "${HOME}/.ssh/deploy_key" "${HOME}/.ssh/known_hosts"
+          ssh-keygen -y -f "${HOME}/.ssh/deploy_key" >/dev/null
+
+      - name: Redeploy every active service
+        run: |
+          ssh \
+            -i "${HOME}/.ssh/deploy_key" \
+            -o BatchMode=yes \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=15 \
+            u.hsc.qlty@200.16.7.138 \
+            "cd /home/u.hsc.qlty/sihsalus && bash -s" \
+            <scripts/deploy/redeploy-environment.sh
+
+      - name: Verify QLTY externally
+        run: |
+          set -euo pipefail
+          base='https://gidis-hsc-qlty.inf.pucp.edu.pe'
+          curl --insecure --fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 5 \
+            "${base}/health" >/dev/null
+          curl --insecure --fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 5 \
+            "${base}/ready" >/dev/null
+          curl --insecure --fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 5 \
+            "${base}/openmrs/health/started" >/dev/null
+          curl --insecure --fail --silent --show-error \
+            "${base}/openmrs/spa/build-info.json"
+          curl --insecure --fail --silent --show-error \
+            "${base}/openmrs/spa/sihsalus-spa-bootstrap.js" |
+            grep -q 'initializeSpa'
+          csp="$(curl --insecure --fail --silent --show-error --head "${base}/openmrs/spa/" |
+            awk 'BEGIN { IGNORECASE=1 } /^content-security-policy:/ { sub(/\r$/, ""); print; exit }')"
+          grep -Fq "script-src 'self';" <<<"${csp}"
+          if grep -Fq "script-src 'self' 'unsafe-inline'" <<<"${csp}"; then
+            echo "QLTY still permits inline SPA scripts" >&2
+            exit 1
+          fi

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -46,3 +46,25 @@ actualización, la imagen anterior permanece disponible hasta que terminan la
 verificación y la posibilidad de rollback automático. Una reversión posterior
 a un despliegue exitoso vuelve a descargar por digest y reconstruir el frontend
 anterior.
+
+## Redeploy integral no destructivo
+
+`redeploy-environment.sh` se usa para reconstruir y recrear un ambiente
+completo cuando una actualización exclusiva del frontend no es suficiente.
+Opera sobre los archivos y perfiles definidos por el `.env` del servidor:
+
+1. rechaza cambios locales en archivos versionados y el perfil destructivo
+   `seed`;
+2. actualiza `main` únicamente mediante fast-forward;
+3. descarga la imagen configurada del backend clásico
+   `ghcr.io/sihsalus/sihsalus-backend`, construido desde `backend/pom.xml`;
+4. descarga las imágenes de registry de todos los perfiles activos;
+5. reconstruye sin caché los runtimes locales activos (`frontend`, `gateway`,
+   `certbot` y/o `keycloak`);
+6. recrea todos los servicios activos, pero conserva volúmenes y datos;
+7. espera MariaDB, frontend, OpenMRS y gateway, y verifica el estado de todos
+   los servicios antes de declarar el ambiente usable.
+
+No ejecuta `docker compose down`, no usa `-v` y no elimina volúmenes. El
+workflow manual `Redeploy Non-Production` ejecuta primero DEV y solo promueve a
+QLTY si DEV y sus verificaciones HTTP terminan correctamente.

--- a/scripts/deploy/redeploy-environment.sh
+++ b/scripts/deploy/redeploy-environment.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+if [ "$#" -ne 0 ]; then
+  echo "Usage: $0" >&2
+  exit 2
+fi
+
+for command in docker git awk grep head seq sleep; do
+  command -v "$command" >/dev/null 2>&1 || {
+    echo "[redeploy-environment] missing command: $command" >&2
+    exit 2
+  }
+done
+
+if [ ! -f docker-compose.yml ] || [ ! -f .env ]; then
+  echo "[redeploy-environment] run from the sihsalus repository root" >&2
+  exit 2
+fi
+
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+  echo "[redeploy-environment] tracked files contain local changes; refusing to overwrite them" >&2
+  exit 1
+fi
+
+diagnose_failure() {
+  local exit_code="${1:-$?}"
+  trap - ERR HUP INT TERM
+  echo "[redeploy-environment] redeploy failed; current container state follows" >&2
+  docker compose ps --all >&2 || true
+  exit "$exit_code"
+}
+
+trap 'diagnose_failure $?' ERR
+trap 'diagnose_failure 129' HUP
+trap 'diagnose_failure 130' INT
+trap 'diagnose_failure 143' TERM
+
+service_is_active() {
+  local service="$1"
+  grep -Fxq "$service" <<<"$ACTIVE_SERVICES"
+}
+
+container_health() {
+  local container="$1"
+  docker inspect "$container" \
+    --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' \
+    2>/dev/null || true
+}
+
+wait_for_container_health() {
+  local container="$1"
+  local timeout_seconds="$2"
+  local elapsed=0
+  local health
+
+  while [ "$elapsed" -lt "$timeout_seconds" ]; do
+    health="$(container_health "$container")"
+    case "$health" in
+      healthy | running)
+        echo "[redeploy-environment] ${container} is ${health}"
+        return 0
+        ;;
+      unhealthy | exited | dead)
+        echo "[redeploy-environment] ${container} entered state: ${health}" >&2
+        return 1
+        ;;
+    esac
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+
+  echo "[redeploy-environment] ${container} did not become healthy within ${timeout_seconds}s" >&2
+  return 1
+}
+
+wait_for_openmrs() {
+  local timeout_seconds="$1"
+  local elapsed=0
+
+  while [ "$elapsed" -lt "$timeout_seconds" ]; do
+    if docker exec sihsalus-backend \
+      curl --fail --silent --show-error --max-time 10 \
+      http://127.0.0.1:8080/openmrs/health/started >/dev/null 2>&1; then
+      echo "[redeploy-environment] OpenMRS reports started"
+      return 0
+    fi
+
+    health="$(container_health sihsalus-backend)"
+    case "$health" in
+      unhealthy | exited | dead)
+        echo "[redeploy-environment] OpenMRS entered state: ${health}" >&2
+        return 1
+        ;;
+    esac
+    sleep 15
+    elapsed=$((elapsed + 15))
+  done
+
+  echo "[redeploy-environment] OpenMRS did not report started within ${timeout_seconds}s" >&2
+  return 1
+}
+
+wait_for_active_services() {
+  local timeout_seconds="$1"
+  local elapsed=0
+  local service
+  local container_id
+  local state
+  local health
+  local exit_code
+  local pending
+
+  while [ "$elapsed" -lt "$timeout_seconds" ]; do
+    pending=false
+
+    while IFS= read -r service; do
+      [ -n "$service" ] || continue
+      container_id="$(docker compose ps --all --quiet "$service" | head -n 1)"
+      if [ -z "$container_id" ]; then
+        pending=true
+        continue
+      fi
+
+      state="$(docker inspect "$container_id" --format '{{.State.Status}}')"
+      health="$(docker inspect "$container_id" --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}')"
+      exit_code="$(docker inspect "$container_id" --format '{{.State.ExitCode}}')"
+
+      if [ "$service" = "backend-oauth2-config" ] && [ "$state" = "exited" ] && [ "$exit_code" = "0" ]; then
+        continue
+      fi
+      case "$state" in
+        running)
+          if [ -n "$health" ] && [ "$health" != "healthy" ]; then
+            pending=true
+          fi
+          ;;
+        created | restarting)
+          pending=true
+          ;;
+        *)
+          echo "[redeploy-environment] ${service} is ${state} (exit ${exit_code})" >&2
+          return 1
+          ;;
+      esac
+    done <<<"$ACTIVE_SERVICES"
+
+    if [ "$pending" = false ]; then
+      echo "[redeploy-environment] every active service is ready"
+      return 0
+    fi
+
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+
+  echo "[redeploy-environment] active services did not become ready within ${timeout_seconds}s" >&2
+  return 1
+}
+
+echo "[redeploy-environment] updating distro checkout"
+git fetch origin main
+git merge --ff-only origin/main
+
+docker compose config --quiet
+ACTIVE_SERVICES="$(docker compose config --services)"
+
+if service_is_active seed; then
+  echo "[redeploy-environment] the destructive seed profile must not be active during a redeploy" >&2
+  false
+fi
+
+echo "[redeploy-environment] active services"
+printf '%s\n' "$ACTIVE_SERVICES"
+
+echo "[redeploy-environment] pulling the configured classic OpenMRS backend"
+docker compose pull backend
+
+echo "[redeploy-environment] pulling registry images for active non-buildable services"
+docker compose pull --ignore-buildable --ignore-pull-failures
+
+BUILD_SERVICES=(frontend gateway)
+for build_service in certbot keycloak; do
+  if service_is_active "$build_service"; then
+    BUILD_SERVICES+=("$build_service")
+  fi
+done
+
+echo "[redeploy-environment] rebuilding local runtime services without cache: ${BUILD_SERVICES[*]}"
+docker compose build --pull --no-cache "${BUILD_SERVICES[@]}"
+
+echo "[redeploy-environment] recreating every active service without deleting volumes"
+docker compose up \
+  --detach \
+  --force-recreate \
+  --remove-orphans \
+  --no-build \
+  --pull never
+
+wait_for_container_health sihsalus-db-master 300
+wait_for_container_health sihsalus-frontend 600
+wait_for_openmrs 2400
+wait_for_container_health sihsalus-backend 120
+wait_for_container_health sihsalus-gateway 600
+
+wait_for_active_services 600
+
+BACKEND_IMAGE="$(docker inspect sihsalus-backend --format '{{.Config.Image}}')"
+case "$BACKEND_IMAGE" in
+  ghcr.io/sihsalus/sihsalus-backend:*)
+    ;;
+  *)
+    echo "[redeploy-environment] backend is not using the classic distro image: ${BACKEND_IMAGE}" >&2
+    false
+    ;;
+esac
+
+FRONTEND_SHA="$(
+  docker exec sihsalus-frontend wget -qO- http://127.0.0.1/build-info.json |
+    awk -F'"' '/"gitSha"[[:space:]]*:/ { print $4; exit }'
+)"
+if [[ ! "$FRONTEND_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "[redeploy-environment] frontend build-info does not contain a valid SHA" >&2
+  false
+fi
+
+trap - ERR HUP INT TERM
+echo "[redeploy-environment] usable"
+echo "[redeploy-environment] distro=$(git rev-parse HEAD)"
+echo "[redeploy-environment] backend=${BACKEND_IMAGE}"
+echo "[redeploy-environment] frontend=${FRONTEND_SHA}"
+docker compose ps

--- a/tests/deploy/redeploy-environment-policy.sh
+++ b/tests/deploy/redeploy-environment-policy.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/deploy/redeploy-environment.sh"
+
+bash -n "$SCRIPT"
+
+if grep -Eq 'docker compose down|docker (volume|system) (rm|prune)|docker image prune|docker compose .* (--volumes|-v)( |$)' "$SCRIPT"; then
+  echo "[FAIL] full redeploy script contains a data-destructive Docker operation" >&2
+  exit 1
+fi
+
+grep -Fq 'git merge --ff-only origin/main' "$SCRIPT"
+grep -Fq 'docker compose pull backend' "$SCRIPT"
+grep -Fq 'docker compose build --pull --no-cache "${BUILD_SERVICES[@]}"' "$SCRIPT"
+grep -Fq -- '--force-recreate' "$SCRIPT"
+grep -Fq -- '--remove-orphans' "$SCRIPT"
+grep -Fq -- '--no-build' "$SCRIPT"
+grep -Fq -- '--pull never' "$SCRIPT"
+grep -Fq 'wait_for_openmrs 2400' "$SCRIPT"
+grep -Fq 'wait_for_active_services 600' "$SCRIPT"
+grep -Fq 'ghcr.io/sihsalus/sihsalus-backend:' "$SCRIPT"
+
+echo "[OK] full environment redeploy policy"


### PR DESCRIPTION
## Resumen

- añade un redeploy integral manual y secuencial DEV → QLTY
- usa el backend clásico `ghcr.io/sihsalus/sihsalus-backend` construido desde `backend/pom.xml`
- reconstruye sin caché los runtimes locales y recrea todos los servicios/perfiles activos
- conserva volúmenes y datos; prohíbe `seed`, `down`, `-v` y prune global
- espera MariaDB, frontend, OpenMRS `/health/started`, gateway y todos los servicios activos
- bloquea QLTY si DEV o su smoke test externo fallan

## Validación local

- política de redeploy: OK
- `bash -n`: OK
- modelos Compose e invariantes semánticas: OK
- despliegue/rollback frontend existente: OK
- YAML parseado: OK

## Contexto

El hallazgo de auditoría se movió al distro como #218. `sihsalus-core` no forma parte de la runtime actual.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->