### PR TITLE
fix(deploy): support validated offline full redeploys

### DIFF
--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -68,3 +68,9 @@ Opera sobre los archivos y perfiles definidos por el `.env` del servidor:
 No ejecuta `docker compose down`, no usa `-v` y no elimina volúmenes. El
 workflow manual `Redeploy Non-Production` ejecuta primero DEV y solo promueve a
 QLTY si DEV y sus verificaciones HTTP terminan correctamente.
+
+Si un establecimiento está temporalmente sin DNS o salida a Internet, se puede
+usar `REDEPLOY_OFFLINE=true` únicamente después de transferir y verificar el
+checkout y todas las imágenes runtime deseadas. Ese modo omite `git fetch`, los
+pulls y los builds; recrea los servicios exclusivamente con las imágenes
+prevalidadas que ya estén presentes. No cambia las versiones fijadas en `.env`.

--- a/scripts/deploy/redeploy-environment.sh
+++ b/scripts/deploy/redeploy-environment.sh
@@ -7,6 +7,16 @@ if [ "$#" -ne 0 ]; then
   exit 2
 fi
 
+REDEPLOY_OFFLINE="${REDEPLOY_OFFLINE:-false}"
+case "$REDEPLOY_OFFLINE" in
+  true | false)
+    ;;
+  *)
+    echo "[redeploy-environment] REDEPLOY_OFFLINE must be true or false" >&2
+    exit 2
+    ;;
+esac
+
 for command in docker git awk grep head seq sleep; do
   command -v "$command" >/dev/null 2>&1 || {
     echo "[redeploy-environment] missing command: $command" >&2
@@ -40,6 +50,17 @@ trap 'diagnose_failure 143' TERM
 service_is_active() {
   local service="$1"
   grep -Fxq "$service" <<<"$ACTIVE_SERVICES"
+}
+
+service_allows_successful_exit() {
+  case "$1" in
+    backend-oauth2-config | certbot)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
 }
 
 container_health() {
@@ -127,7 +148,9 @@ wait_for_active_services() {
       health="$(docker inspect "$container_id" --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}')"
       exit_code="$(docker inspect "$container_id" --format '{{.State.ExitCode}}')"
 
-      if [ "$service" = "backend-oauth2-config" ] && [ "$state" = "exited" ] && [ "$exit_code" = "0" ]; then
+      if service_allows_successful_exit "$service" &&
+        [ "$state" = "exited" ] &&
+        [ "$exit_code" = "0" ]; then
         continue
       fi
       case "$state" in
@@ -159,9 +182,13 @@ wait_for_active_services() {
   return 1
 }
 
-echo "[redeploy-environment] updating distro checkout"
-git fetch origin main
-git merge --ff-only origin/main
+if [ "$REDEPLOY_OFFLINE" = true ]; then
+  echo "[redeploy-environment] offline mode: using the prevalidated local checkout and images"
+else
+  echo "[redeploy-environment] updating distro checkout"
+  git fetch origin main
+  git merge --ff-only origin/main
+fi
 
 docker compose config --quiet
 ACTIVE_SERVICES="$(docker compose config --services)"
@@ -174,21 +201,27 @@ fi
 echo "[redeploy-environment] active services"
 printf '%s\n' "$ACTIVE_SERVICES"
 
-echo "[redeploy-environment] pulling the configured classic OpenMRS backend"
-docker compose pull backend
+if [ "$REDEPLOY_OFFLINE" = false ]; then
+  echo "[redeploy-environment] pulling the configured classic OpenMRS backend"
+  docker compose pull backend
 
-echo "[redeploy-environment] pulling registry images for active non-buildable services"
-docker compose pull --ignore-buildable --ignore-pull-failures
+  echo "[redeploy-environment] pulling registry images for active non-buildable services"
+  docker compose pull --ignore-buildable --ignore-pull-failures
+fi
 
-BUILD_SERVICES=(frontend gateway)
-for build_service in certbot keycloak; do
-  if service_is_active "$build_service"; then
-    BUILD_SERVICES+=("$build_service")
-  fi
-done
+if [ "$REDEPLOY_OFFLINE" = false ]; then
+  BUILD_SERVICES=(frontend gateway)
+  for build_service in certbot keycloak; do
+    if service_is_active "$build_service"; then
+      BUILD_SERVICES+=("$build_service")
+    fi
+  done
 
-echo "[redeploy-environment] rebuilding local runtime services without cache: ${BUILD_SERVICES[*]}"
-docker compose build --pull --no-cache "${BUILD_SERVICES[@]}"
+  echo "[redeploy-environment] rebuilding local runtime services without cache: ${BUILD_SERVICES[*]}"
+  docker compose build --pull --no-cache "${BUILD_SERVICES[@]}"
+else
+  echo "[redeploy-environment] offline mode: using prevalidated local runtime images without rebuilding"
+fi
 
 echo "[redeploy-environment] recreating every active service without deleting volumes"
 docker compose up \

--- a/tests/deploy/redeploy-environment-policy.sh
+++ b/tests/deploy/redeploy-environment-policy.sh
@@ -14,13 +14,16 @@ fi
 
 grep -Fq 'git merge --ff-only origin/main' "$SCRIPT"
 grep -Fq 'docker compose pull backend' "$SCRIPT"
+grep -Fq 'REDEPLOY_OFFLINE="${REDEPLOY_OFFLINE:-false}"' "$SCRIPT"
 grep -Fq 'docker compose build --pull --no-cache "${BUILD_SERVICES[@]}"' "$SCRIPT"
+grep -Fq 'offline mode: using prevalidated local runtime images without rebuilding' "$SCRIPT"
 grep -Fq -- '--force-recreate' "$SCRIPT"
 grep -Fq -- '--remove-orphans' "$SCRIPT"
 grep -Fq -- '--no-build' "$SCRIPT"
 grep -Fq -- '--pull never' "$SCRIPT"
 grep -Fq 'wait_for_openmrs 2400' "$SCRIPT"
 grep -Fq 'wait_for_active_services 600' "$SCRIPT"
+grep -Fq 'backend-oauth2-config | certbot)' "$SCRIPT"
 grep -Fq 'ghcr.io/sihsalus/sihsalus-backend:' "$SCRIPT"
 
 echo "[OK] full environment redeploy policy"


### PR DESCRIPTION
## Resumen
- añade un modo offline explícito para establecimientos sin DNS/salida pública
- exige checkout e imágenes runtime prevalidadas y recrea todo sin pulls, builds ni borrado de volúmenes
- acepta la salida exitosa de los inicializadores `backend-oauth2-config` y `certbot`
- documenta el procedimiento y amplía la prueba de política destructiva

## Validación
- `bash tests/deploy/redeploy-environment-policy.sh`
- `bash -n scripts/deploy/redeploy-environment.sh`
- `git diff --check`
- ejecutado en PowerEdge con los 8 servicios recreados, OpenMRS/FUA/SPA saludables y datos preservados

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->