### PR TITLE
feat(keycloak): bound session lifetime and make TOTP available

### DIFF
--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -10,6 +10,27 @@
     "bruteForceProtected": true,
     "maxFailureWaitSeconds": 300,
     "failureFactor": 5,
+
+    "ssoSessionIdleTimeout": 1800,
+    "ssoSessionMaxLifespan": 28800,
+    "offlineSessionIdleTimeout": 1800,
+
+    "otpPolicyType": "totp",
+    "otpPolicyAlgorithm": "HmacSHA1",
+    "otpPolicyDigits": 6,
+    "otpPolicyPeriod": 30,
+    "otpPolicyLookAheadWindow": 1,
+    "requiredActions": [
+        {
+            "alias": "CONFIGURE_TOTP",
+            "name": "Configure OTP",
+            "providerId": "CONFIGURE_TOTP",
+            "enabled": true,
+            "defaultAction": false,
+            "priority": 10,
+            "config": {}
+        }
+    ],
     "passwordPolicy": "length(8) and digits(1) and lowerCase(1) and upperCase(1) and notUsername(undefined)",
     "roles": {
         "realm": [


### PR DESCRIPTION
## Why

The realm already had brute-force protection (5 attempts, 300s wait) and a real password policy, but **no session limits at all** — a login stayed valid until the browser closed. On a shared hospital terminal that is the gap that matters: whoever sits down next inherits the chart the last person left open.

```
ssoSessionIdleTimeout      — no definido
ssoSessionMaxLifespan      — no definido
offlineSessionIdleTimeout  — no definido
otpPolicyType              — no definido
```

## Change

| Clave | Valor | Por qué |
|---|---|---|
| `ssoSessionIdleTimeout` | 1800 (30 min) | Bounds an unattended terminal |
| `ssoSessionMaxLifespan` | 28800 (8 h) | Covers one shift without spanning two |
| `offlineSessionIdleTimeout` | 1800 | Would otherwise outlive both caps |
| `otpPolicyType` + policy | totp / SHA1 / 6 / 30s | Realm can issue and verify TOTP |
| `requiredActions` | `CONFIGURE_TOTP`, `defaultAction: false` | Available, not forced |

Offline sessions are safe to bound here: neither `openmrs` nor `sihsalus-imaging` enables service accounts or requests `offline_access`, so nothing depends on them outliving a user session.

## Why TOTP is not mandatory

I went to the source before building. Directiva 333-MINSA/OGTI-2025, **N0.GBL.004**:

> Todas las entidades que tienen acceso al SIHCE están sujetas a la autenticación… con diversos niveles de rigor
> El sistema DEBE autenticar a las entidades (p. ej. usuarios, organizaciones, aplicaciones, componentes)

It requires authentication, **not a second factor**. N0.GBL.005 and .006 are authorization and access rules, already covered by the RBAC in the frontend.

Making enrolment mandatory would also lock out the shared accounts the team currently tests with, for a requirement the norm does not impose. So the policy is defined and the action is offered; flipping `defaultAction` to `true` is a one-line change the day the team decides to enforce it, with everything else already in place.

## Verification

- `json.load` parses clean; 24 top-level keys.
- The diff is **21 insertions, 0 deletions** — keys inserted as text at 4-space indent rather than re-serialising, so the rest of the file is untouched. (A first pass that round-tripped through `json.dumps` rewrote 239 lines for 9 keys; discarded.)
- CI runs the imaging auth runtime test on any change under `keycloak/`, which boots Keycloak with this realm and exercises the OAuth flow — a malformed realm fails the import and the job.

## Note on rollout

The `keycloak` compose profile is **not currently enabled** in dev or qlty (`COMPOSE_PROFILES=ssl,fua`, zero Keycloak containers running). This change makes the realm correct for when it is switched on; it does not switch it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->