### PR TITLE
chore(backend): use SIHSALUS content 1.23.9

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -62,7 +62,7 @@
     <fua.version>1.0.86</fua.version>
     <imaging.version>1.2.8</imaging.version>
     <!-- Content Packages -->
-    <sihsalus-content.version>1.23.8</sihsalus-content.version>
+    <sihsalus-content.version>1.23.9</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
   </properties>
 


### PR DESCRIPTION
## Resumen

- actualiza el backend de SIHSALUS content 1.23.8 a 1.23.9
- incorpora los privilegios de lectura/creación de adjuntos para Consulta Externa

## Validación previa

- sihsalus-content#182 fusionado
- artefactos POM y ZIP 1.23.9 disponibles en Maven Central
- validación integrada de contenido con backend/OpenMRS: verde
- build Maven local del distro: en ejecución; el PR Gate vuelve a construir en CI

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->