### PR TITLE
fix(deploy): pin backend during full redeploy

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -28,7 +28,7 @@ MYSQL_OPENMRS_PASSWORD=openmrs
 MYSQL_ROOT_PASSWORD=openmrs
 OMRS_OCL_TOKEN=
 
-# Imágenes. En producción usa tags inmutables (por ejemplo sha-...).
+# Imágenes. En producción usa referencias inmutables (por ejemplo sha-...@sha256:...).
 BACKEND_TAG=latest
 FRONTEND_SOURCE_TAG=latest
 FRONTEND_RUNTIME_TAG=latest

--- a/.github/workflows/redeploy-non-production.yml
+++ b/.github/workflows/redeploy-non-production.yml
@@ -8,6 +8,14 @@ on:
         required: true
         default: false
         type: boolean
+      backend_sha:
+        description: Backend source commit (40 lowercase hexadecimal characters)
+        required: true
+        type: string
+      backend_digest:
+        description: 'Immutable backend image digest (sha256: followed by 64 lowercase hexadecimal characters)'
+        required: true
+        type: string
 
 concurrency:
   group: redeploy-non-production
@@ -44,15 +52,29 @@ jobs:
           ssh-keygen -y -f "${HOME}/.ssh/deploy_key" >/dev/null
 
       - name: Redeploy every active service
+        env:
+          TARGET_BACKEND_SHA: ${{ inputs.backend_sha }}
+          TARGET_BACKEND_DIGEST: ${{ inputs.backend_digest }}
         run: |
+          set -euo pipefail
+          if [[ ! "${TARGET_BACKEND_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::The requested backend SHA is invalid."
+            exit 2
+          fi
+          if [[ ! "${TARGET_BACKEND_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::The requested backend digest is invalid."
+            exit 2
+          fi
           ssh \
             -i "${HOME}/.ssh/deploy_key" \
             -o BatchMode=yes \
             -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=yes \
             -o ConnectTimeout=15 \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=6 \
             u.hsc.dev@200.16.7.137 \
-            "cd /home/u.hsc.dev/sihsalus && bash -s" \
+            "cd /home/u.hsc.dev/sihsalus && bash -s -- '${TARGET_BACKEND_SHA}' '${TARGET_BACKEND_DIGEST}'" \
             <scripts/deploy/redeploy-environment.sh
 
       - name: Verify DEV externally
@@ -106,15 +128,29 @@ jobs:
           ssh-keygen -y -f "${HOME}/.ssh/deploy_key" >/dev/null
 
       - name: Redeploy every active service
+        env:
+          TARGET_BACKEND_SHA: ${{ inputs.backend_sha }}
+          TARGET_BACKEND_DIGEST: ${{ inputs.backend_digest }}
         run: |
+          set -euo pipefail
+          if [[ ! "${TARGET_BACKEND_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::The requested backend SHA is invalid."
+            exit 2
+          fi
+          if [[ ! "${TARGET_BACKEND_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::The requested backend digest is invalid."
+            exit 2
+          fi
           ssh \
             -i "${HOME}/.ssh/deploy_key" \
             -o BatchMode=yes \
             -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=yes \
             -o ConnectTimeout=15 \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=6 \
             u.hsc.qlty@200.16.7.138 \
-            "cd /home/u.hsc.qlty/sihsalus && bash -s" \
+            "cd /home/u.hsc.qlty/sihsalus && bash -s -- '${TARGET_BACKEND_SHA}' '${TARGET_BACKEND_DIGEST}'" \
             <scripts/deploy/redeploy-environment.sh
 
       - name: Verify QLTY externally

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Si el entorno también usa Keycloak u otros overrides, añade esos mismos `-f` y
 ### Backend (si cambió la imagen del backend)
 
 ```bash
-export BACKEND_TAG=sha-<digest>
+export BACKEND_TAG=sha-<commit>@sha256:<digest>
 
 # Stack HTTP/local
 docker compose pull backend

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -51,26 +51,43 @@ anterior.
 
 `redeploy-environment.sh` se usa para reconstruir y recrear un ambiente
 completo cuando una actualización exclusiva del frontend no es suficiente.
+Recibe el commit y digest ya publicados del backend para que un `BACKEND_TAG`
+antiguo en el servidor no pueda degradar el despliegue:
+
+```bash
+./scripts/deploy/redeploy-environment.sh \
+  0123456789abcdef0123456789abcdef01234567 \
+  sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+```
+
 Opera sobre los archivos y perfiles definidos por el `.env` del servidor:
 
 1. rechaza cambios locales en archivos versionados y el perfil destructivo
    `seed`;
 2. actualiza `main` únicamente mediante fast-forward;
-3. descarga la imagen configurada del backend clásico
-   `ghcr.io/sihsalus/sihsalus-backend`, construido desde `backend/pom.xml`;
+3. descarga por digest la imagen solicitada del backend clásico
+   `ghcr.io/sihsalus/sihsalus-backend`, construido desde `backend/pom.xml`, y
+   valida que su revisión OCI coincida con el commit solicitado;
 4. descarga las imágenes de registry de todos los perfiles activos;
 5. reconstruye sin caché los runtimes locales activos (`frontend`, `gateway`,
    `certbot` y/o `keycloak`);
 6. recrea todos los servicios activos, pero conserva volúmenes y datos;
 7. espera MariaDB, frontend, OpenMRS y gateway, y verifica el estado de todos
-   los servicios antes de declarar el ambiente usable.
+   los servicios antes de declarar el ambiente usable;
+8. solo entonces persiste en `.env` la referencia inmutable
+   `sha-<commit>@sha256:<digest>` usada por el backend.
 
 No ejecuta `docker compose down`, no usa `-v` y no elimina volúmenes. El
-workflow manual `Redeploy Non-Production` ejecuta primero DEV y solo promueve a
-QLTY si DEV y sus verificaciones HTTP terminan correctamente.
+workflow manual `Redeploy Non-Production` solicita el SHA y digest del backend,
+ejecuta primero DEV y solo promueve a QLTY si DEV y sus verificaciones HTTP
+terminan correctamente. La conexión usa keepalive y la espera de OpenMRS emite
+progreso periódico para tolerar arranques largos.
 
 Si un establecimiento está temporalmente sin DNS o salida a Internet, se puede
 usar `REDEPLOY_OFFLINE=true` únicamente después de transferir y verificar el
 checkout y todas las imágenes runtime deseadas. Ese modo omite `git fetch`, los
 pulls y los builds; recrea los servicios exclusivamente con las imágenes
-prevalidadas que ya estén presentes. No cambia las versiones fijadas en `.env`.
+prevalidadas que ya estén presentes. También exige el SHA y digest del backend;
+la referencia por digest debe haberse descargado explícitamente o transferido
+con sus metadatos de `RepoDigest`. La referencia solo se persiste después de
+completar las verificaciones.

--- a/scripts/deploy/redeploy-environment.sh
+++ b/scripts/deploy/redeploy-environment.sh
@@ -2,8 +2,25 @@
 
 set -Eeuo pipefail
 
-if [ "$#" -ne 0 ]; then
-  echo "Usage: $0" >&2
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <40-character backend git SHA> <sha256 image digest>" >&2
+  exit 2
+fi
+
+TARGET_BACKEND_SHA="$1"
+TARGET_BACKEND_DIGEST="$2"
+TARGET_BACKEND_TAG="sha-${TARGET_BACKEND_SHA}"
+BACKEND_REPOSITORY="ghcr.io/sihsalus/sihsalus-backend"
+TARGET_BACKEND_REFERENCE="${TARGET_BACKEND_TAG}@${TARGET_BACKEND_DIGEST}"
+EXPECTED_BACKEND_IMAGE="${BACKEND_REPOSITORY}:${TARGET_BACKEND_REFERENCE}"
+
+if [[ ! "$TARGET_BACKEND_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "[redeploy-environment] invalid backend SHA" >&2
+  exit 2
+fi
+
+if [[ ! "$TARGET_BACKEND_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  echo "[redeploy-environment] invalid backend image digest" >&2
   exit 2
 fi
 
@@ -17,7 +34,7 @@ case "$REDEPLOY_OFFLINE" in
     ;;
 esac
 
-for command in docker git awk grep head seq sleep; do
+for command in docker git awk chmod mktemp mv rm grep head seq sleep; do
   command -v "$command" >/dev/null 2>&1 || {
     echo "[redeploy-environment] missing command: $command" >&2
     exit 2
@@ -28,6 +45,36 @@ if [ ! -f docker-compose.yml ] || [ ! -f .env ]; then
   echo "[redeploy-environment] run from the sihsalus repository root" >&2
   exit 2
 fi
+
+write_env_value() {
+  local key="$1"
+  local value="$2"
+  local temporary_file
+  temporary_file="$(mktemp ./.env.redeploy.XXXXXX)"
+
+  if ! awk -v key="$key" -v value="$value" '
+    BEGIN { found = 0 }
+    $0 ~ ("^" key "=") {
+      print key "=" value
+      found = 1
+      next
+    }
+    { print }
+    END {
+      if (!found) {
+        print key "=" value
+      }
+    }
+  ' .env >"$temporary_file"; then
+    rm -f "$temporary_file"
+    return 1
+  fi
+
+  if ! chmod --reference=.env "$temporary_file" || ! mv -f "$temporary_file" .env; then
+    rm -f "$temporary_file"
+    return 1
+  fi
+}
 
 if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
   echo "[redeploy-environment] tracked files contain local changes; refusing to overwrite them" >&2
@@ -99,6 +146,7 @@ wait_for_container_health() {
 wait_for_openmrs() {
   local timeout_seconds="$1"
   local elapsed=0
+  local health
 
   while [ "$elapsed" -lt "$timeout_seconds" ]; do
     if docker exec sihsalus-backend \
@@ -115,6 +163,10 @@ wait_for_openmrs() {
         return 1
         ;;
     esac
+
+    if [ $((elapsed % 60)) -eq 0 ]; then
+      echo "[redeploy-environment] waiting for OpenMRS (${elapsed}s/${timeout_seconds}s)"
+    fi
     sleep 15
     elapsed=$((elapsed + 15))
   done
@@ -190,6 +242,10 @@ else
   git merge --ff-only origin/main
 fi
 
+# Override a stale server .env for every Compose operation. The same immutable
+# reference is persisted only after the complete environment is healthy.
+export BACKEND_TAG="$TARGET_BACKEND_REFERENCE"
+
 docker compose config --quiet
 ACTIVE_SERVICES="$(docker compose config --services)"
 
@@ -207,6 +263,15 @@ if [ "$REDEPLOY_OFFLINE" = false ]; then
 
   echo "[redeploy-environment] pulling registry images for active non-buildable services"
   docker compose pull --ignore-buildable --ignore-pull-failures
+fi
+
+BACKEND_SOURCE_REVISION="$(
+  docker image inspect "${BACKEND_REPOSITORY}@${TARGET_BACKEND_DIGEST}" \
+    --format '{{index .Config.Labels "org.opencontainers.image.revision"}}'
+)"
+if [ "$BACKEND_SOURCE_REVISION" != "$TARGET_BACKEND_SHA" ]; then
+  echo "[redeploy-environment] backend image revision does not match requested SHA" >&2
+  false
 fi
 
 if [ "$REDEPLOY_OFFLINE" = false ]; then
@@ -240,14 +305,20 @@ wait_for_container_health sihsalus-gateway 600
 wait_for_active_services 600
 
 BACKEND_IMAGE="$(docker inspect sihsalus-backend --format '{{.Config.Image}}')"
-case "$BACKEND_IMAGE" in
-  ghcr.io/sihsalus/sihsalus-backend:*)
-    ;;
-  *)
-    echo "[redeploy-environment] backend is not using the classic distro image: ${BACKEND_IMAGE}" >&2
-    false
-    ;;
-esac
+if [ "$BACKEND_IMAGE" != "$EXPECTED_BACKEND_IMAGE" ]; then
+  echo "[redeploy-environment] backend image is not the requested immutable release: ${BACKEND_IMAGE}" >&2
+  false
+fi
+
+BACKEND_IMAGE_ID="$(docker inspect sihsalus-backend --format '{{.Image}}')"
+BACKEND_REVISION="$(
+  docker image inspect "$BACKEND_IMAGE_ID" \
+    --format '{{index .Config.Labels "org.opencontainers.image.revision"}}'
+)"
+if [ "$BACKEND_REVISION" != "$TARGET_BACKEND_SHA" ]; then
+  echo "[redeploy-environment] deployed backend revision does not match requested SHA" >&2
+  false
+fi
 
 FRONTEND_SHA="$(
   docker exec sihsalus-frontend wget -qO- http://127.0.0.1/build-info.json |
@@ -257,6 +328,9 @@ if [[ ! "$FRONTEND_SHA" =~ ^[0-9a-f]{40}$ ]]; then
   echo "[redeploy-environment] frontend build-info does not contain a valid SHA" >&2
   false
 fi
+
+write_env_value BACKEND_TAG "$TARGET_BACKEND_REFERENCE"
+echo "[redeploy-environment] persisted immutable backend reference"
 
 trap - ERR HUP INT TERM
 echo "[redeploy-environment] usable"

--- a/tests/deploy/redeploy-environment-policy.sh
+++ b/tests/deploy/redeploy-environment-policy.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT/scripts/deploy/redeploy-environment.sh"
+WORKFLOW="$ROOT/.github/workflows/redeploy-non-production.yml"
 
 bash -n "$SCRIPT"
 
@@ -13,6 +14,8 @@ if grep -Eq 'docker compose down|docker (volume|system) (rm|prune)|docker image 
 fi
 
 grep -Fq 'git merge --ff-only origin/main' "$SCRIPT"
+grep -Fq 'Usage: $0 <40-character backend git SHA> <sha256 image digest>' "$SCRIPT"
+grep -Fq 'export BACKEND_TAG="$TARGET_BACKEND_REFERENCE"' "$SCRIPT"
 grep -Fq 'docker compose pull backend' "$SCRIPT"
 grep -Fq 'REDEPLOY_OFFLINE="${REDEPLOY_OFFLINE:-false}"' "$SCRIPT"
 grep -Fq 'docker compose build --pull --no-cache "${BUILD_SERVICES[@]}"' "$SCRIPT"
@@ -24,6 +27,17 @@ grep -Fq -- '--pull never' "$SCRIPT"
 grep -Fq 'wait_for_openmrs 2400' "$SCRIPT"
 grep -Fq 'wait_for_active_services 600' "$SCRIPT"
 grep -Fq 'backend-oauth2-config | certbot)' "$SCRIPT"
-grep -Fq 'ghcr.io/sihsalus/sihsalus-backend:' "$SCRIPT"
+grep -Fq 'EXPECTED_BACKEND_IMAGE="${BACKEND_REPOSITORY}:${TARGET_BACKEND_REFERENCE}"' "$SCRIPT"
+grep -Fq 'BACKEND_SOURCE_REVISION' "$SCRIPT"
+grep -Fq 'write_env_value BACKEND_TAG "$TARGET_BACKEND_REFERENCE"' "$SCRIPT"
+grep -Fq 'mktemp ./.env.redeploy.XXXXXX' "$SCRIPT"
+grep -Fq 'chmod --reference=.env "$temporary_file"' "$SCRIPT"
+grep -Fq 'mv -f "$temporary_file" .env' "$SCRIPT"
+grep -Fq 'waiting for OpenMRS' "$SCRIPT"
+grep -Fq 'backend_sha:' "$WORKFLOW"
+grep -Fq 'backend_digest:' "$WORKFLOW"
+[ "$(grep -Fc -- '-o ServerAliveInterval=30' "$WORKFLOW")" -eq 2 ]
+[ "$(grep -Fc -- '-o ServerAliveCountMax=6' "$WORKFLOW")" -eq 2 ]
+[ "$(grep -Fc "bash -s -- '\${TARGET_BACKEND_SHA}' '\${TARGET_BACKEND_DIGEST}'" "$WORKFLOW")" -eq 2 ]
 
 echo "[OK] full environment redeploy policy"


### PR DESCRIPTION
## Objetivo

Evitar que el redeploy integral reutilice silenciosamente el BACKEND_TAG antiguo del servidor y que una espera larga de OpenMRS pierda la sesión SSH.

## Cambios

- Requiere SHA y digest inmutables del backend en el workflow manual.
- Valida ambos inputs antes de SSH y la revisión OCI antes de recrear servicios.
- Usa sha-commit@sha256:digest en todas las operaciones Compose y lo persiste atómicamente solo después de verificar salud.
- Añade keepalive SSH y progreso periódico durante el arranque de OpenMRS.
- Actualiza política y documentación operativa.

## Validación

- [x] bash -n scripts/deploy/redeploy-environment.sh
- [x] ./tests/deploy/redeploy-environment-policy.sh
- [x] ./scripts/validate-compose.sh compose-validation
- [x] Parseo YAML del workflow
- [x] docker compose config con el SHA/digest objetivo
- [x] git diff --check
- [x] No incluí credenciales, tokens, datos clínicos ni datos personales.

## Evidencia y rollback

El backend publicado sha-a0e5c55f90a89794b73546aea88ceb904cd1e9ec resuelve al digest sha256:5a4fc1783f7d48d91916df68dcaa27ba43218e1cb71d8063eecd21294b1072fd. El redeploy conserva volúmenes. Para rollback, ejecutar nuevamente el workflow con el SHA y digest inmutables anteriores; la referencia de .env solo se consolida tras verificaciones exitosas.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->