### PR TITLE
fix(deploy): serialize full redeploy builds

### DIFF
--- a/.github/workflows/redeploy-non-production.yml
+++ b/.github/workflows/redeploy-non-production.yml
@@ -72,7 +72,7 @@ jobs:
             -o StrictHostKeyChecking=yes \
             -o ConnectTimeout=15 \
             -o ServerAliveInterval=30 \
-            -o ServerAliveCountMax=6 \
+            -o ServerAliveCountMax=20 \
             u.hsc.dev@200.16.7.137 \
             "cd /home/u.hsc.dev/sihsalus && bash -s -- '${TARGET_BACKEND_SHA}' '${TARGET_BACKEND_DIGEST}'" \
             <scripts/deploy/redeploy-environment.sh
@@ -148,7 +148,7 @@ jobs:
             -o StrictHostKeyChecking=yes \
             -o ConnectTimeout=15 \
             -o ServerAliveInterval=30 \
-            -o ServerAliveCountMax=6 \
+            -o ServerAliveCountMax=20 \
             u.hsc.qlty@200.16.7.138 \
             "cd /home/u.hsc.qlty/sihsalus && bash -s -- '${TARGET_BACKEND_SHA}' '${TARGET_BACKEND_DIGEST}'" \
             <scripts/deploy/redeploy-environment.sh

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -69,8 +69,9 @@ Opera sobre los archivos y perfiles definidos por el `.env` del servidor:
    `ghcr.io/sihsalus/sihsalus-backend`, construido desde `backend/pom.xml`, y
    valida que su revisión OCI coincida con el commit solicitado;
 4. descarga las imágenes de registry de todos los perfiles activos;
-5. reconstruye sin caché los runtimes locales activos (`frontend`, `gateway`,
-   `certbot` y/o `keycloak`);
+5. reconstruye sin caché y de forma secuencial los runtimes locales activos
+   (`frontend`, `gateway`, `certbot` y/o `keycloak`) para limitar el consumo de
+   CPU, memoria y red del host;
 6. recrea todos los servicios activos, pero conserva volúmenes y datos;
 7. espera MariaDB, frontend, OpenMRS y gateway, y verifica el estado de todos
    los servicios antes de declarar el ambiente usable;
@@ -80,8 +81,9 @@ Opera sobre los archivos y perfiles definidos por el `.env` del servidor:
 No ejecuta `docker compose down`, no usa `-v` y no elimina volúmenes. El
 workflow manual `Redeploy Non-Production` solicita el SHA y digest del backend,
 ejecuta primero DEV y solo promueve a QLTY si DEV y sus verificaciones HTTP
-terminan correctamente. La conexión usa keepalive y la espera de OpenMRS emite
-progreso periódico para tolerar arranques largos.
+terminan correctamente. La conexión usa keepalive con tolerancia de diez
+minutos y la espera de OpenMRS emite progreso periódico para tolerar arranques
+largos.
 
 Si un establecimiento está temporalmente sin DNS o salida a Internet, se puede
 usar `REDEPLOY_OFFLINE=true` únicamente después de transferir y verificar el

--- a/scripts/deploy/redeploy-environment.sh
+++ b/scripts/deploy/redeploy-environment.sh
@@ -282,8 +282,11 @@ if [ "$REDEPLOY_OFFLINE" = false ]; then
     fi
   done
 
-  echo "[redeploy-environment] rebuilding local runtime services without cache: ${BUILD_SERVICES[*]}"
-  docker compose build --pull --no-cache "${BUILD_SERVICES[@]}"
+  echo "[redeploy-environment] rebuilding local runtime services sequentially without cache: ${BUILD_SERVICES[*]}"
+  for build_service in "${BUILD_SERVICES[@]}"; do
+    echo "[redeploy-environment] rebuilding ${build_service}"
+    docker compose build --pull --no-cache "$build_service"
+  done
 else
   echo "[redeploy-environment] offline mode: using prevalidated local runtime images without rebuilding"
 fi

--- a/tests/deploy/redeploy-environment-policy.sh
+++ b/tests/deploy/redeploy-environment-policy.sh
@@ -18,7 +18,8 @@ grep -Fq 'Usage: $0 <40-character backend git SHA> <sha256 image digest>' "$SCRI
 grep -Fq 'export BACKEND_TAG="$TARGET_BACKEND_REFERENCE"' "$SCRIPT"
 grep -Fq 'docker compose pull backend' "$SCRIPT"
 grep -Fq 'REDEPLOY_OFFLINE="${REDEPLOY_OFFLINE:-false}"' "$SCRIPT"
-grep -Fq 'docker compose build --pull --no-cache "${BUILD_SERVICES[@]}"' "$SCRIPT"
+grep -Fq 'for build_service in "${BUILD_SERVICES[@]}"; do' "$SCRIPT"
+grep -Fq 'docker compose build --pull --no-cache "$build_service"' "$SCRIPT"
 grep -Fq 'offline mode: using prevalidated local runtime images without rebuilding' "$SCRIPT"
 grep -Fq -- '--force-recreate' "$SCRIPT"
 grep -Fq -- '--remove-orphans' "$SCRIPT"
@@ -37,7 +38,7 @@ grep -Fq 'waiting for OpenMRS' "$SCRIPT"
 grep -Fq 'backend_sha:' "$WORKFLOW"
 grep -Fq 'backend_digest:' "$WORKFLOW"
 [ "$(grep -Fc -- '-o ServerAliveInterval=30' "$WORKFLOW")" -eq 2 ]
-[ "$(grep -Fc -- '-o ServerAliveCountMax=6' "$WORKFLOW")" -eq 2 ]
+[ "$(grep -Fc -- '-o ServerAliveCountMax=20' "$WORKFLOW")" -eq 2 ]
 [ "$(grep -Fc "bash -s -- '\${TARGET_BACKEND_SHA}' '\${TARGET_BACKEND_DIGEST}'" "$WORKFLOW")" -eq 2 ]
 
 echo "[OK] full environment redeploy policy"


### PR DESCRIPTION
## Objetivo

Evitar que un host no productivo quede sin capacidad de responder a SSH mientras Compose/BuildKit recompila varios runtimes en paralelo.

## Contexto

El run 30847844725 dejó DEV completamente verde, pero QLTY perdió conectividad durante el build simultáneo de frontend, gateway y certbot. No llegó a compose up, no persistió BACKEND_TAG y omitió la verificación externa.

## Cambios

- Reconstruye frontend, gateway, certbot y keycloak secuencialmente, conservando --pull y --no-cache.
- Amplía la tolerancia SSH de 180 a 600 segundos.
- Actualiza política y documentación operativa.

## Validación

- [x] bash -n scripts/deploy/redeploy-environment.sh
- [x] ./tests/deploy/redeploy-environment-policy.sh
- [x] Parseo YAML del workflow
- [x] docker compose config con el backend objetivo fijado por digest
- [x] git diff --check
- [x] Revisión independiente sin bloqueantes
- [x] No incluí credenciales, tokens, datos clínicos ni datos personales.

## Evidencia y rollback

El último output QLTY fue un build paralelo y 210 segundos después SSH agotó 30s x 6. El loop reduce presión de CPU, RAM y red; 30s x 20 permite recuperaciones de hasta diez minutos. Rollback: revertir este PR restaura builds paralelos y el umbral anterior; no hay cambio de datos ni volúmenes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->