### PR TITLE
fix(backend): deploy upstream-synced SIHSALUS bed flows

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -24,6 +24,7 @@ jobs:
       contents: read
       id-token: write
       packages: write
+      security-events: write
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -41,7 +42,6 @@ jobs:
           images: ghcr.io/sihsalus/sihsalus-backend
           tags: |
             type=sha,prefix=sha-,format=long
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - uses: docker/build-push-action@v7
         id: build
@@ -49,11 +49,103 @@ jobs:
           context: .
           file: backend/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ghcr.io/sihsalus/sihsalus-backend:sha-${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
           cache-from: type=gha,scope=backend
           cache-to: type=gha,scope=backend,mode=max
+
+      - name: Resolve pinned OpenMRS security baseline
+        id: openmrs-baseline
+        run: |
+          set -euo pipefail
+          baseline_image="$(sed -n 's/^ARG OPENMRS_RUNTIME_IMAGE=//p' backend/Dockerfile)"
+          if [[ ! "${baseline_image}" =~ ^openmrs/openmrs-core:[a-zA-Z0-9._-]+@sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::The OpenMRS runtime baseline is not pinned to an immutable digest."
+            exit 1
+          fi
+          echo "image=${baseline_image}" >>"${GITHUB_OUTPUT}"
+
+      - name: Scan immutable backend candidate
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ghcr.io/sihsalus/sihsalus-backend@${{ steps.build.outputs.digest }}
+          format: json
+          output: trivy-backend-candidate.json
+          severity: HIGH,CRITICAL
+          exit-code: '0'
+          ignore-unfixed: true
+          vuln-type: os,library
+
+      - name: Scan pinned OpenMRS baseline
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ steps.openmrs-baseline.outputs.image }}
+          format: json
+          output: trivy-openmrs-baseline.json
+          severity: HIGH,CRITICAL
+          exit-code: '0'
+          ignore-unfixed: true
+          vuln-type: os,library
+
+      - name: Enforce backend vulnerability ratchet
+        run: |
+          set -euo pipefail
+          candidate_total="$(jq '[.Results[]? | (.Vulnerabilities // [])[]] | length' trivy-backend-candidate.json)"
+          baseline_total="$(jq '[.Results[]? | (.Vulnerabilities // [])[]] | length' trivy-openmrs-baseline.json)"
+          candidate_os="$(jq '[.Results[]? | select(.Class == "os-pkgs") | (.Vulnerabilities // [])[]] | length' trivy-backend-candidate.json)"
+          unexpected="$(
+            jq -n \
+              --slurpfile candidate trivy-backend-candidate.json \
+              --slurpfile baseline trivy-openmrs-baseline.json \
+              'def findings($report):
+                 [$report[0].Results[]? | (.Vulnerabilities // [])[] |
+                  "\(.VulnerabilityID)|\(.PkgName)|\(.InstalledVersion)"] | unique;
+               findings($candidate) - findings($baseline)'
+          )"
+          unexpected_total="$(jq 'length' <<<"${unexpected}")"
+
+          {
+            echo '### Backend vulnerability ratchet'
+            echo "- Candidate HIGH/CRITICAL findings: ${candidate_total}"
+            echo "- Upstream OpenMRS baseline findings: ${baseline_total}"
+            echo "- Candidate OS findings with fixes: ${candidate_os}"
+            echo "- Findings added beyond upstream: ${unexpected_total}"
+          } >>"${GITHUB_STEP_SUMMARY}"
+
+          if [[ "${candidate_os}" != '0' ]]; then
+            echo '::error::The backend still contains fixable HIGH/CRITICAL operating-system vulnerabilities.'
+            jq -r '.Results[]? | select(.Class == "os-pkgs") | (.Vulnerabilities // [])[] |
+              "\(.Severity) \(.VulnerabilityID) \(.PkgName) \(.InstalledVersion) -> \(.FixedVersion)"' \
+              trivy-backend-candidate.json
+            exit 1
+          fi
+
+          if [[ "${unexpected_total}" != '0' ]]; then
+            echo '::error::The SIHSALUS backend adds HIGH/CRITICAL vulnerabilities beyond its pinned OpenMRS base.'
+            jq -r '.[]' <<<"${unexpected}"
+            exit 1
+          fi
+
+      - name: Produce backend Trivy evidence
+        if: always()
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ghcr.io/sihsalus/sihsalus-backend@${{ steps.build.outputs.digest }}
+          format: sarif
+          output: trivy-backend-results.sarif
+          severity: HIGH,CRITICAL
+          exit-code: '0'
+          ignore-unfixed: true
+          vuln-type: os,library
+          limit-severities-for-sarif: true
+
+      - name: Upload backend Trivy evidence
+        if: ${{ always() && hashFiles('trivy-backend-results.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-backend-results.sarif
+          category: trivy-backend
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.1.2
@@ -62,6 +154,19 @@ jobs:
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
         run: cosign sign --yes "ghcr.io/sihsalus/sihsalus-backend@${DIGEST}"
+
+      - name: Promote verified backend image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          image='ghcr.io/sihsalus/sihsalus-backend'
+          docker buildx imagetools create --prefer-index=false --tag "${image}:latest" "${image}@${DIGEST}"
+          promoted_digest="$(docker buildx imagetools inspect "${image}:latest" --format '{{.Manifest.Digest}}')"
+          if [[ "${promoted_digest}" != "${DIGEST}" ]]; then
+            echo "::error::The promoted backend alias does not resolve to the scanned digest."
+            exit 1
+          fi
 
       - name: Make package public
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,9 @@ jobs:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -135,6 +138,98 @@ jobs:
         env:
           DOCKER_BUILDKIT: '1'
         run: docker build --file backend/Dockerfile --tag sihsalus-backend:ci .
+
+      - name: Resolve pinned OpenMRS security baseline
+        id: openmrs-baseline
+        run: |
+          set -euo pipefail
+          baseline_image="$(sed -n 's/^ARG OPENMRS_RUNTIME_IMAGE=//p' backend/Dockerfile)"
+          if [[ ! "${baseline_image}" =~ ^openmrs/openmrs-core:[a-zA-Z0-9._-]+@sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::The OpenMRS runtime baseline is not pinned to an immutable digest."
+            exit 1
+          fi
+          echo "image=${baseline_image}" >>"${GITHUB_OUTPUT}"
+
+      - name: Scan backend candidate
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: sihsalus-backend:ci
+          format: json
+          output: trivy-backend-candidate.json
+          severity: HIGH,CRITICAL
+          exit-code: '0'
+          ignore-unfixed: true
+          vuln-type: os,library
+
+      - name: Scan pinned OpenMRS baseline
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ steps.openmrs-baseline.outputs.image }}
+          format: json
+          output: trivy-openmrs-baseline.json
+          severity: HIGH,CRITICAL
+          exit-code: '0'
+          ignore-unfixed: true
+          vuln-type: os,library
+
+      - name: Enforce backend vulnerability ratchet
+        run: |
+          set -euo pipefail
+          candidate_total="$(jq '[.Results[]? | (.Vulnerabilities // [])[]] | length' trivy-backend-candidate.json)"
+          baseline_total="$(jq '[.Results[]? | (.Vulnerabilities // [])[]] | length' trivy-openmrs-baseline.json)"
+          candidate_os="$(jq '[.Results[]? | select(.Class == "os-pkgs") | (.Vulnerabilities // [])[]] | length' trivy-backend-candidate.json)"
+          unexpected="$(
+            jq -n \
+              --slurpfile candidate trivy-backend-candidate.json \
+              --slurpfile baseline trivy-openmrs-baseline.json \
+              'def findings($report):
+                 [$report[0].Results[]? | (.Vulnerabilities // [])[] |
+                  "\(.VulnerabilityID)|\(.PkgName)|\(.InstalledVersion)"] | unique;
+               findings($candidate) - findings($baseline)'
+          )"
+          unexpected_total="$(jq 'length' <<<"${unexpected}")"
+
+          {
+            echo '### Backend vulnerability ratchet'
+            echo "- Candidate HIGH/CRITICAL findings: ${candidate_total}"
+            echo "- Upstream OpenMRS baseline findings: ${baseline_total}"
+            echo "- Candidate OS findings with fixes: ${candidate_os}"
+            echo "- Findings added beyond upstream: ${unexpected_total}"
+          } >>"${GITHUB_STEP_SUMMARY}"
+
+          if [[ "${candidate_os}" != '0' ]]; then
+            echo '::error::The backend still contains fixable HIGH/CRITICAL operating-system vulnerabilities.'
+            jq -r '.Results[]? | select(.Class == "os-pkgs") | (.Vulnerabilities // [])[] |
+              "\(.Severity) \(.VulnerabilityID) \(.PkgName) \(.InstalledVersion) -> \(.FixedVersion)"' \
+              trivy-backend-candidate.json
+            exit 1
+          fi
+
+          if [[ "${unexpected_total}" != '0' ]]; then
+            echo '::error::The SIHSALUS backend adds HIGH/CRITICAL vulnerabilities beyond its pinned OpenMRS base.'
+            jq -r '.[]' <<<"${unexpected}"
+            exit 1
+          fi
+
+      - name: Produce backend Trivy evidence
+        if: always()
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: sihsalus-backend:ci
+          format: sarif
+          output: trivy-backend-results.sarif
+          severity: HIGH,CRITICAL
+          exit-code: '0'
+          ignore-unfixed: true
+          vuln-type: os,library
+          limit-severities-for-sarif: true
+
+      - name: Upload backend Trivy evidence
+        if: ${{ always() && hashFiles('trivy-backend-results.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-backend-results.sarif
+          category: trivy-backend
 
   backup:
     name: Backup round-trip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,19 +127,14 @@ jobs:
     needs: changes
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Set up JDK 8
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: '8'
-          cache: maven
-
-      - name: Build backend distribution
-        run: mvn --batch-mode --update-snapshots --file backend/pom.xml clean package
+      - name: Build deployable backend image
+        env:
+          DOCKER_BUILDKIT: '1'
+        run: docker build --file backend/Dockerfile --tag sihsalus-backend:ci .
 
   backup:
     name: Backup round-trip

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,8 +19,8 @@ COPY backend/pom.xml ./backend/
 
 # Build the SIHSALUS Bed Management patch from an immutable source revision.
 # The checksum prevents a changed or substituted archive from entering the image.
-ARG BEDMANAGEMENT_SOURCE_SHA=270e00f1cdcf856ed939ccb987de3a48107208ca
-ADD --checksum=sha256:d104e361f925d6045829b437c7f778cfb75c8a3d454a4e837fc624285cafdc34 \
+ARG BEDMANAGEMENT_SOURCE_SHA=e2bb2f3f297e2cb6e292779f78c97f1fe33a917c
+ADD --checksum=sha256:cc96957c0a84a19ee503cd1ad6270801215f7c47cf66c35a0583dfa7304b889e \
     https://github.com/sihsalus/openmrs-module-bedmanagement/archive/${BEDMANAGEMENT_SOURCE_SHA}.tar.gz \
     /tmp/bedmanagement-source.tar.gz
 RUN --mount=type=cache,target=/root/.m2/repository \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,8 +19,8 @@ COPY backend/pom.xml ./backend/
 
 # Build the SIHSALUS Bed Management patch from an immutable source revision.
 # The checksum prevents a changed or substituted archive from entering the image.
-ARG BEDMANAGEMENT_SOURCE_SHA=e2bb2f3f297e2cb6e292779f78c97f1fe33a917c
-ADD --checksum=sha256:cc96957c0a84a19ee503cd1ad6270801215f7c47cf66c35a0583dfa7304b889e \
+ARG BEDMANAGEMENT_SOURCE_SHA=4927f1ac9406f63717c92a71035fd9092ce01bab
+ADD --checksum=sha256:1a06525581a6eab8d2a2b3b7ff677f2e4695dca730b71a706c622ad79f8d9f31 \
     https://github.com/sihsalus/openmrs-module-bedmanagement/archive/${BEDMANAGEMENT_SOURCE_SHA}.tar.gz \
     /tmp/bedmanagement-source.tar.gz
 RUN --mount=type=cache,target=/root/.m2/repository \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -51,6 +51,13 @@ RUN cp /openmrs_distro/backend/target/sdk-distro/web/openmrs_core/openmrs.war /o
 # Runtime stays pinned to the exact OpenMRS patch version used in production.
 FROM ${OPENMRS_RUNTIME_IMAGE}
 
+# The upstream Amazon Linux 2 image is immutable, so apply the security updates
+# that became available after its publication before dropping back to UID 1001.
+USER root
+RUN yum -y update expat glib2 libssh2 python python-libs vim-data vim-minimal && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
 # The pinned OpenMRS runtime quotes the wildcard used to clear distribution
 # directories, so removed modules and metadata survive in the persistent volume.
 # Keep the upstream safety guard while allowing the wildcard to expand.
@@ -74,3 +81,5 @@ COPY --from=dev /openmrs/distribution/openmrs_owas /openmrs/distribution/openmrs
 COPY --from=dev  /openmrs/distribution/openmrs_config /openmrs/distribution/openmrs_config
 
 RUN mkdir -p /openmrs/data
+
+USER 1001

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,6 +17,19 @@ ARG MVN_ARGS="install"
 COPY pom.xml ./
 COPY backend/pom.xml ./backend/
 
+# Build the SIHSALUS Bed Management patch from an immutable source revision.
+# The checksum prevents a changed or substituted archive from entering the image.
+ARG BEDMANAGEMENT_SOURCE_SHA=270e00f1cdcf856ed939ccb987de3a48107208ca
+ADD --checksum=sha256:d104e361f925d6045829b437c7f778cfb75c8a3d454a4e837fc624285cafdc34 \
+    https://github.com/sihsalus/openmrs-module-bedmanagement/archive/${BEDMANAGEMENT_SOURCE_SHA}.tar.gz \
+    /tmp/bedmanagement-source.tar.gz
+RUN --mount=type=cache,target=/root/.m2/repository \
+    mkdir -p /tmp/bedmanagement-source && \
+    tar -xzf /tmp/bedmanagement-source.tar.gz -C /tmp/bedmanagement-source --strip-components=1 && \
+    mvn --batch-mode --show-version --no-transfer-progress \
+      -Dformatter.skip=true -DskipTests -Dmaven.javadoc.skip=true \
+      --file /tmp/bedmanagement-source/pom.xml install
+
 # Pre-download all dependencies into the BuildKit cache.
 RUN --mount=type=cache,target=/root/.m2/repository \
     mvn $MVN_ARGS_SETTINGS dependency:resolve -B || true

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -54,7 +54,7 @@
     <o3forms.version>2.3.0</o3forms.version>
     <emrapi.version>3.4.0</emrapi.version>
     <event.version>4.0.0</event.version>
-    <bedmanagement.version>7.2.1-sihsalus.1</bedmanagement.version>
+    <bedmanagement.version>7.3.0-sihsalus.1</bedmanagement.version>
     <!-- Stock Management and Billing -->
     <stockmanagement.version>3.1.1</stockmanagement.version>
     <billing.version>2.3.0</billing.version>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -54,7 +54,7 @@
     <o3forms.version>2.3.0</o3forms.version>
     <emrapi.version>3.4.0</emrapi.version>
     <event.version>4.0.0</event.version>
-    <bedmanagement.version>7.2.0</bedmanagement.version>
+    <bedmanagement.version>7.2.1-sihsalus.1</bedmanagement.version>
     <!-- Stock Management and Billing -->
     <stockmanagement.version>3.1.1</stockmanagement.version>
     <billing.version>2.3.0</billing.version>


### PR DESCRIPTION
## Resumen

- empaqueta Bed Management `7.3.0-sihsalus.1` desde el upstream actual `6d4b70b` más las extensiones SIHSALUS
- fija el commit fuente `4927f1a` y valida su archivo con SHA-256 inmutable
- conserva estados operativos y tags de camas de SIHSALUS
- incorpora los fixes upstream de tipo de cama y flush prematuro de Hibernate
- permite finalizar una visita clínica sin otorgar privilegios administrativos de camas ni `Get Global Properties` al usuario
- mantiene protegidas las APIs directas de gestión de camas
- construye y escanea en CI exactamente la imagen backend que será desplegada

## Orden de despliegue

Este backend debe llegar a DEV antes del frontend que consume `/ws/rest/v1/clinicalvisitclosure`.

## Verificación

- módulo: 171 pruebas verdes en Java 21; CI independiente Java 8/21 en ejecución
- effective POM resuelve `7.3.0-sihsalus.1`
- archivo fuente SHA-256: `1a06525581a6eab8d2a2b3b7ff677f2e4695dca730b71a706c622ad79f8d9f31`
- CI construye la imagen Docker y aplica el ratchet Trivy contra la base OpenMRS fijada