### PR TITLE
fix(deploy): survive transient SSH disconnects

### DIFF
--- a/.github/workflows/redeploy-non-production.yml
+++ b/.github/workflows/redeploy-non-production.yml
@@ -65,17 +65,13 @@ jobs:
             echo "::error::The requested backend digest is invalid."
             exit 2
           fi
-          ssh \
-            -i "${HOME}/.ssh/deploy_key" \
-            -o BatchMode=yes \
-            -o IdentitiesOnly=yes \
-            -o StrictHostKeyChecking=yes \
-            -o ConnectTimeout=15 \
-            -o ServerAliveInterval=30 \
-            -o ServerAliveCountMax=20 \
+          scripts/deploy/run-redeploy-remote.sh \
+            "${HOME}/.ssh/deploy_key" \
             u.hsc.dev@200.16.7.137 \
-            "cd /home/u.hsc.dev/sihsalus && bash -s -- '${TARGET_BACKEND_SHA}' '${TARGET_BACKEND_DIGEST}'" \
-            <scripts/deploy/redeploy-environment.sh
+            /home/u.hsc.dev/sihsalus \
+            "${TARGET_BACKEND_SHA}" \
+            "${TARGET_BACKEND_DIGEST}" \
+            "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-dev"
 
       - name: Verify DEV externally
         run: |
@@ -141,17 +137,13 @@ jobs:
             echo "::error::The requested backend digest is invalid."
             exit 2
           fi
-          ssh \
-            -i "${HOME}/.ssh/deploy_key" \
-            -o BatchMode=yes \
-            -o IdentitiesOnly=yes \
-            -o StrictHostKeyChecking=yes \
-            -o ConnectTimeout=15 \
-            -o ServerAliveInterval=30 \
-            -o ServerAliveCountMax=20 \
+          scripts/deploy/run-redeploy-remote.sh \
+            "${HOME}/.ssh/deploy_key" \
             u.hsc.qlty@200.16.7.138 \
-            "cd /home/u.hsc.qlty/sihsalus && bash -s -- '${TARGET_BACKEND_SHA}' '${TARGET_BACKEND_DIGEST}'" \
-            <scripts/deploy/redeploy-environment.sh
+            /home/u.hsc.qlty/sihsalus \
+            "${TARGET_BACKEND_SHA}" \
+            "${TARGET_BACKEND_DIGEST}" \
+            "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-qlty"
 
       - name: Verify QLTY externally
         run: |

--- a/scripts/deploy/run-redeploy-remote.sh
+++ b/scripts/deploy/run-redeploy-remote.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REDEPLOY_SCRIPT_PATH="${REDEPLOY_SCRIPT_PATH:-$ROOT/redeploy-environment.sh}"
+SSH_BIN="${SSH_BIN:-ssh}"
+POLL_INTERVAL_SECONDS="${REDEPLOY_POLL_INTERVAL_SECONDS:-10}"
+TIMEOUT_SECONDS="${REDEPLOY_TIMEOUT_SECONDS:-3300}"
+MAX_TRANSPORT_FAILURES="${REDEPLOY_MAX_TRANSPORT_FAILURES:-20}"
+
+usage() {
+  echo "Usage: $0 <ssh-key> <user@host> <remote-repository> <backend-sha> <backend-digest> <run-token>" >&2
+}
+
+if [ "$#" -ne 6 ]; then
+  usage
+  exit 2
+fi
+
+SSH_KEY="$1"
+REMOTE_TARGET="$2"
+REMOTE_REPOSITORY="$3"
+TARGET_BACKEND_SHA="$4"
+TARGET_BACKEND_DIGEST="$5"
+RUN_TOKEN="$6"
+
+if [ ! -r "$SSH_KEY" ]; then
+  echo "[remote-redeploy] SSH key is not readable" >&2
+  exit 2
+fi
+if [ ! -r "$REDEPLOY_SCRIPT_PATH" ]; then
+  echo "[remote-redeploy] redeploy script is not readable" >&2
+  exit 2
+fi
+if [[ ! "$REMOTE_TARGET" =~ ^[A-Za-z0-9._-]+@[A-Za-z0-9._:-]+$ ]]; then
+  echo "[remote-redeploy] invalid SSH target" >&2
+  exit 2
+fi
+if [[ ! "$REMOTE_REPOSITORY" =~ ^/[A-Za-z0-9._/-]+$ ]]; then
+  echo "[remote-redeploy] invalid remote repository path" >&2
+  exit 2
+fi
+if [[ ! "$TARGET_BACKEND_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "[remote-redeploy] invalid backend SHA" >&2
+  exit 2
+fi
+if [[ ! "$TARGET_BACKEND_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  echo "[remote-redeploy] invalid backend digest" >&2
+  exit 2
+fi
+if [[ ! "$RUN_TOKEN" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "[remote-redeploy] invalid run token" >&2
+  exit 2
+fi
+
+for numeric_value in "$POLL_INTERVAL_SECONDS" "$TIMEOUT_SECONDS" "$MAX_TRANSPORT_FAILURES"; do
+  if [[ ! "$numeric_value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "[remote-redeploy] polling and timeout values must be positive integers" >&2
+    exit 2
+  fi
+done
+
+for command in "$SSH_BIN" cat mktemp rm sleep tr wc; do
+  command -v "$command" >/dev/null 2>&1 || {
+    echo "[remote-redeploy] missing command: $command" >&2
+    exit 2
+  }
+done
+
+SSH_COMMAND=(
+  "$SSH_BIN"
+  -i "$SSH_KEY"
+  -o BatchMode=yes
+  -o IdentitiesOnly=yes
+  -o StrictHostKeyChecking=yes
+  -o ConnectTimeout=15
+  -o ServerAliveInterval=15
+  -o ServerAliveCountMax=3
+)
+
+REMOTE_RUN_DIRECTORY="$REMOTE_REPOSITORY/.redeploy-runs/$RUN_TOKEN"
+REMOTE_SCRIPT="$REMOTE_RUN_DIRECTORY/redeploy-environment.sh"
+REMOTE_LOG="$REMOTE_RUN_DIRECTORY/redeploy.log"
+REMOTE_STATUS="$REMOTE_RUN_DIRECTORY/status"
+REMOTE_PID="$REMOTE_RUN_DIRECTORY/pid"
+
+echo "[remote-redeploy] uploading the validated redeploy script"
+"${SSH_COMMAND[@]}" "$REMOTE_TARGET" \
+  "umask 077; install -d -m 700 '$REMOTE_RUN_DIRECTORY'; cat >'$REMOTE_SCRIPT'; chmod 700 '$REMOTE_SCRIPT'" \
+  <"$REDEPLOY_SCRIPT_PATH"
+
+echo "[remote-redeploy] starting detached run $RUN_TOKEN"
+"${SSH_COMMAND[@]}" "$REMOTE_TARGET" bash -s -- \
+  "$REMOTE_REPOSITORY" \
+  "$RUN_TOKEN" \
+  "$TARGET_BACKEND_SHA" \
+  "$TARGET_BACKEND_DIGEST" <<'REMOTE_LAUNCHER'
+set -Eeuo pipefail
+
+repository="$1"
+run_token="$2"
+backend_sha="$3"
+backend_digest="$4"
+run_directory="$repository/.redeploy-runs/$run_token"
+script_path="$run_directory/redeploy-environment.sh"
+log_path="$run_directory/redeploy.log"
+status_path="$run_directory/status"
+pid_path="$run_directory/pid"
+
+for command in bash flock nohup setsid; do
+  command -v "$command" >/dev/null 2>&1 || {
+    echo "[remote-redeploy] missing remote command: $command" >&2
+    exit 2
+  }
+done
+
+if [ ! -x "$script_path" ]; then
+  echo "[remote-redeploy] uploaded script is not executable" >&2
+  exit 2
+fi
+if [ -e "$status_path" ]; then
+  echo "[remote-redeploy] run token already completed; refusing to overwrite evidence" >&2
+  exit 1
+fi
+if [ -f "$pid_path" ]; then
+  previous_pid="$(cat "$pid_path")"
+  if [[ "$previous_pid" =~ ^[1-9][0-9]*$ ]] && kill -0 "$previous_pid" 2>/dev/null; then
+    echo "[remote-redeploy] run token is already active" >&2
+    exit 1
+  fi
+fi
+
+: >"$log_path"
+rm -f "$run_directory/status.tmp"
+
+nohup setsid bash -c '
+  set +e
+  repository="$1"
+  run_directory="$2"
+  backend_sha="$3"
+  backend_digest="$4"
+  log_path="$run_directory/redeploy.log"
+  status_path="$run_directory/status"
+  status_tmp="$run_directory/status.tmp"
+
+  exec >"$log_path" 2>&1
+
+  write_status() {
+    exit_code="$?"
+    trap - EXIT
+    printf "%s\n" "$exit_code" >"$status_tmp"
+    mv -f "$status_tmp" "$status_path"
+  }
+
+  trap write_status EXIT
+  trap "exit 130" INT
+  trap "exit 143" TERM HUP
+
+  cd "$repository" || exit 1
+  exec 9>"$repository/.redeploy-runs/redeploy.lock"
+  if ! flock -n 9; then
+    echo "[remote-redeploy] another environment redeploy is active" >&2
+    exit 75
+  fi
+
+  bash "$run_directory/redeploy-environment.sh" "$backend_sha" "$backend_digest"
+  exit "$?"
+' remote-redeploy-worker \
+  "$repository" \
+  "$run_directory" \
+  "$backend_sha" \
+  "$backend_digest" \
+  </dev/null >/dev/null 2>&1 &
+
+printf '%s\n' "$!" >"$pid_path"
+REMOTE_LAUNCHER
+
+REMOTE_FINISHED=false
+NEXT_LOG_LINE=1
+TRANSPORT_FAILURES=0
+START_SECONDS="$SECONDS"
+CURRENT_TEMP_FILE=""
+
+fetch_remote_log() {
+  local line_count
+  CURRENT_TEMP_FILE="$(mktemp "${TMPDIR:-/tmp}/sihsalus-redeploy-log.XXXXXX")"
+  if ! "${SSH_COMMAND[@]}" "$REMOTE_TARGET" \
+    tail -n "+${NEXT_LOG_LINE}" -- "$REMOTE_LOG" >"$CURRENT_TEMP_FILE"; then
+    rm -f "$CURRENT_TEMP_FILE"
+    CURRENT_TEMP_FILE=""
+    return 1
+  fi
+
+  cat "$CURRENT_TEMP_FILE"
+  line_count="$(wc -l <"$CURRENT_TEMP_FILE" | tr -d ' ')"
+  NEXT_LOG_LINE=$((NEXT_LOG_LINE + line_count))
+  rm -f "$CURRENT_TEMP_FILE"
+  CURRENT_TEMP_FILE=""
+}
+
+cancel_remote_run() {
+  "${SSH_COMMAND[@]}" "$REMOTE_TARGET" bash -s -- \
+    "$REMOTE_STATUS" "$REMOTE_PID" <<'REMOTE_CANCEL' || true
+set -euo pipefail
+status_path="$1"
+pid_path="$2"
+
+if [ -f "$status_path" ] || [ ! -f "$pid_path" ]; then
+  exit 0
+fi
+
+remote_pid="$(cat "$pid_path")"
+if [[ "$remote_pid" =~ ^[1-9][0-9]*$ ]]; then
+  kill -TERM -- "-${remote_pid}" 2>/dev/null || kill -TERM "$remote_pid" 2>/dev/null || true
+fi
+REMOTE_CANCEL
+}
+
+finish_local() {
+  local exit_code="$?"
+  trap - EXIT
+  if [ -n "$CURRENT_TEMP_FILE" ]; then
+    rm -f "$CURRENT_TEMP_FILE"
+  fi
+  if [ "$REMOTE_FINISHED" != true ]; then
+    echo "[remote-redeploy] local monitor stopped; terminating the detached remote run" >&2
+    cancel_remote_run
+  fi
+  exit "$exit_code"
+}
+
+trap finish_local EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM HUP
+
+while true; do
+  if [ $((SECONDS - START_SECONDS)) -ge "$TIMEOUT_SECONDS" ]; then
+    echo "[remote-redeploy] remote run exceeded ${TIMEOUT_SECONDS}s" >&2
+    exit 124
+  fi
+
+  if ! fetch_remote_log; then
+    TRANSPORT_FAILURES=$((TRANSPORT_FAILURES + 1))
+    echo "[remote-redeploy] log transport failure ${TRANSPORT_FAILURES}/${MAX_TRANSPORT_FAILURES}" >&2
+  else
+    remote_status=""
+    if remote_status="$(
+      "${SSH_COMMAND[@]}" "$REMOTE_TARGET" bash -s -- "$REMOTE_STATUS" <<'REMOTE_STATUS_CHECK'
+set -euo pipefail
+status_path="$1"
+if [ -f "$status_path" ]; then
+  cat "$status_path"
+fi
+REMOTE_STATUS_CHECK
+    )"; then
+      TRANSPORT_FAILURES=0
+      if [ -n "$remote_status" ]; then
+        if [[ ! "$remote_status" =~ ^[0-9]+$ ]] || [ "$remote_status" -gt 255 ]; then
+          echo "[remote-redeploy] invalid remote status: $remote_status" >&2
+          exit 1
+        fi
+
+        fetch_remote_log || true
+        REMOTE_FINISHED=true
+        if [ "$remote_status" -ne 0 ]; then
+          echo "[remote-redeploy] detached run failed with exit code $remote_status" >&2
+          exit "$remote_status"
+        fi
+        echo "[remote-redeploy] detached run completed successfully"
+        exit 0
+      fi
+    else
+      TRANSPORT_FAILURES=$((TRANSPORT_FAILURES + 1))
+      echo "[remote-redeploy] status transport failure ${TRANSPORT_FAILURES}/${MAX_TRANSPORT_FAILURES}" >&2
+    fi
+  fi
+
+  if [ "$TRANSPORT_FAILURES" -ge "$MAX_TRANSPORT_FAILURES" ]; then
+    echo "[remote-redeploy] SSH transport remained unavailable" >&2
+    exit 255
+  fi
+
+  sleep "$POLL_INTERVAL_SECONDS"
+done

--- a/tests/deploy/redeploy-environment-policy.sh
+++ b/tests/deploy/redeploy-environment-policy.sh
@@ -4,9 +4,13 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT/scripts/deploy/redeploy-environment.sh"
+REMOTE_RUNNER="$ROOT/scripts/deploy/run-redeploy-remote.sh"
+REMOTE_RUNNER_TEST="$ROOT/tests/deploy/run-redeploy-remote-test.sh"
 WORKFLOW="$ROOT/.github/workflows/redeploy-non-production.yml"
 
 bash -n "$SCRIPT"
+bash -n "$REMOTE_RUNNER"
+bash -n "$REMOTE_RUNNER_TEST"
 
 if grep -Eq 'docker compose down|docker (volume|system) (rm|prune)|docker image prune|docker compose .* (--volumes|-v)( |$)' "$SCRIPT"; then
   echo "[FAIL] full redeploy script contains a data-destructive Docker operation" >&2
@@ -37,8 +41,14 @@ grep -Fq 'mv -f "$temporary_file" .env' "$SCRIPT"
 grep -Fq 'waiting for OpenMRS' "$SCRIPT"
 grep -Fq 'backend_sha:' "$WORKFLOW"
 grep -Fq 'backend_digest:' "$WORKFLOW"
-[ "$(grep -Fc -- '-o ServerAliveInterval=30' "$WORKFLOW")" -eq 2 ]
-[ "$(grep -Fc -- '-o ServerAliveCountMax=20' "$WORKFLOW")" -eq 2 ]
-[ "$(grep -Fc "bash -s -- '\${TARGET_BACKEND_SHA}' '\${TARGET_BACKEND_DIGEST}'" "$WORKFLOW")" -eq 2 ]
+[ "$(grep -Fc 'scripts/deploy/run-redeploy-remote.sh' "$WORKFLOW")" -eq 2 ]
+grep -Fq 'nohup setsid bash -c' "$REMOTE_RUNNER"
+grep -Fq 'tail -n "+${NEXT_LOG_LINE}"' "$REMOTE_RUNNER"
+grep -Fq 'kill -TERM -- "-${remote_pid}"' "$REMOTE_RUNNER"
+grep -Fq -- '-o ServerAliveInterval=15' "$REMOTE_RUNNER"
+grep -Fq -- '-o ServerAliveCountMax=3' "$REMOTE_RUNNER"
+grep -Fq 'flock -n 9' "$REMOTE_RUNNER"
+
+bash "$REMOTE_RUNNER_TEST"
 
 echo "[OK] full environment redeploy policy"

--- a/tests/deploy/run-redeploy-remote-test.sh
+++ b/tests/deploy/run-redeploy-remote-test.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT/scripts/deploy/run-redeploy-remote.sh"
+TEMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/sihsalus-remote-redeploy-test.XXXXXX")"
+trap 'rm -rf "$TEMP_ROOT"' EXIT
+
+FAKE_BIN="$TEMP_ROOT/bin"
+REMOTE_REPOSITORY="$TEMP_ROOT/remote/sihsalus"
+SSH_KEY="$TEMP_ROOT/deploy-key"
+mkdir -p "$FAKE_BIN" "$REMOTE_REPOSITORY"
+: >"$SSH_KEY"
+
+cat >"$FAKE_BIN/ssh" <<'FAKE_SSH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -i | -o)
+      shift 2
+      ;;
+    -*)
+      echo "unexpected fake SSH option: $1" >&2
+      exit 2
+      ;;
+    *)
+      shift
+      break
+      ;;
+  esac
+done
+
+if [ "$#" -eq 1 ]; then
+  exec bash -c "$1"
+fi
+exec "$@"
+FAKE_SSH
+
+cat >"$FAKE_BIN/setsid" <<'FAKE_SETSID'
+#!/usr/bin/env bash
+exec "$@"
+FAKE_SETSID
+
+cat >"$FAKE_BIN/flock" <<'FAKE_FLOCK'
+#!/usr/bin/env bash
+exit 0
+FAKE_FLOCK
+
+chmod 700 "$FAKE_BIN/ssh" "$FAKE_BIN/setsid" "$FAKE_BIN/flock"
+
+SUCCESS_FIXTURE="$TEMP_ROOT/success.sh"
+cat >"$SUCCESS_FIXTURE" <<'SUCCESS_SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "fixture started"
+sleep 1
+echo "fixture completed"
+SUCCESS_SCRIPT
+
+FAILURE_FIXTURE="$TEMP_ROOT/failure.sh"
+cat >"$FAILURE_FIXTURE" <<'FAILURE_SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "fixture failed as requested"
+exit 42
+FAILURE_SCRIPT
+
+chmod 700 "$SUCCESS_FIXTURE" "$FAILURE_FIXTURE"
+
+BACKEND_SHA="1111111111111111111111111111111111111111"
+BACKEND_DIGEST="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+SUCCESS_OUTPUT="$TEMP_ROOT/success-output.log"
+PATH="$FAKE_BIN:$PATH" \
+  SSH_BIN="$FAKE_BIN/ssh" \
+  REDEPLOY_SCRIPT_PATH="$SUCCESS_FIXTURE" \
+  REDEPLOY_POLL_INTERVAL_SECONDS=1 \
+  REDEPLOY_TIMEOUT_SECONDS=15 \
+  bash "$RUNNER" \
+  "$SSH_KEY" deploy@example.test "$REMOTE_REPOSITORY" \
+  "$BACKEND_SHA" "$BACKEND_DIGEST" success-run >"$SUCCESS_OUTPUT"
+
+grep -Fq 'fixture started' "$SUCCESS_OUTPUT"
+grep -Fq 'fixture completed' "$SUCCESS_OUTPUT"
+grep -Fq 'detached run completed successfully' "$SUCCESS_OUTPUT"
+[ "$(cat "$REMOTE_REPOSITORY/.redeploy-runs/success-run/status")" = 0 ]
+
+FAILURE_OUTPUT="$TEMP_ROOT/failure-output.log"
+set +e
+PATH="$FAKE_BIN:$PATH" \
+  SSH_BIN="$FAKE_BIN/ssh" \
+  REDEPLOY_SCRIPT_PATH="$FAILURE_FIXTURE" \
+  REDEPLOY_POLL_INTERVAL_SECONDS=1 \
+  REDEPLOY_TIMEOUT_SECONDS=15 \
+  bash "$RUNNER" \
+  "$SSH_KEY" deploy@example.test "$REMOTE_REPOSITORY" \
+  "$BACKEND_SHA" "$BACKEND_DIGEST" failure-run >"$FAILURE_OUTPUT" 2>&1
+failure_code="$?"
+set -e
+
+[ "$failure_code" -eq 42 ]
+grep -Fq 'fixture failed as requested' "$FAILURE_OUTPUT"
+grep -Fq 'detached run failed with exit code 42' "$FAILURE_OUTPUT"
+[ "$(cat "$REMOTE_REPOSITORY/.redeploy-runs/failure-run/status")" = 42 ]
+
+echo "[OK] resilient remote redeploy runner"


### PR DESCRIPTION
## Problema

El redeploy completo de DEV perdió la sesión SSH a los ~5 minutos mientras construía el gateway (`client_loop: send disconnect: Broken pipe`, exit 255). El corte ocurrió antes de `docker compose up`, por lo que DEV permaneció sano con la versión anterior y QLTY no fue tocado.

## Solución

- Ejecutar el redeploy desacoplado de la sesión SSH.
- Supervisar logs y estado mediante conexiones cortas y reintentables.
- Conservar lock remoto, timeout y código de salida real.
- Terminar el grupo remoto si se cancela el monitor.
- Mantener sin cambios el orden DEV → QLTY y la preservación de volúmenes.

## Validación

- `bash tests/deploy/run-redeploy-remote-test.sh`
- `bash tests/deploy/redeploy-environment-policy.sh`
- `actionlint .github/workflows/redeploy-non-production.yml`
- `git diff --check`

Relacionado con el run fallido: https://github.com/sihsalus/sihsalus/actions/runs/30983868882

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->