### PR TITLE
fix(deploy): retry remote redeploy bootstrap

### DIFF
--- a/scripts/deploy/run-redeploy-remote.sh
+++ b/scripts/deploy/run-redeploy-remote.sh
@@ -8,6 +8,7 @@ SSH_BIN="${SSH_BIN:-ssh}"
 POLL_INTERVAL_SECONDS="${REDEPLOY_POLL_INTERVAL_SECONDS:-10}"
 TIMEOUT_SECONDS="${REDEPLOY_TIMEOUT_SECONDS:-3300}"
 MAX_TRANSPORT_FAILURES="${REDEPLOY_MAX_TRANSPORT_FAILURES:-20}"
+INITIAL_TRANSPORT_ATTEMPTS="${REDEPLOY_INITIAL_TRANSPORT_ATTEMPTS:-12}"
 
 usage() {
   echo "Usage: $0 <ssh-key> <user@host> <remote-repository> <backend-sha> <backend-digest> <run-token>" >&2
@@ -54,7 +55,11 @@ if [[ ! "$RUN_TOKEN" =~ ^[A-Za-z0-9._-]+$ ]]; then
   exit 2
 fi
 
-for numeric_value in "$POLL_INTERVAL_SECONDS" "$TIMEOUT_SECONDS" "$MAX_TRANSPORT_FAILURES"; do
+for numeric_value in \
+  "$POLL_INTERVAL_SECONDS" \
+  "$TIMEOUT_SECONDS" \
+  "$MAX_TRANSPORT_FAILURES" \
+  "$INITIAL_TRANSPORT_ATTEMPTS"; do
   if [[ ! "$numeric_value" =~ ^[1-9][0-9]*$ ]]; then
     echo "[remote-redeploy] polling and timeout values must be positive integers" >&2
     exit 2
@@ -85,17 +90,48 @@ REMOTE_LOG="$REMOTE_RUN_DIRECTORY/redeploy.log"
 REMOTE_STATUS="$REMOTE_RUN_DIRECTORY/status"
 REMOTE_PID="$REMOTE_RUN_DIRECTORY/pid"
 
-echo "[remote-redeploy] uploading the validated redeploy script"
-"${SSH_COMMAND[@]}" "$REMOTE_TARGET" \
-  "umask 077; install -d -m 700 '$REMOTE_RUN_DIRECTORY'; cat >'$REMOTE_SCRIPT'; chmod 700 '$REMOTE_SCRIPT'" \
-  <"$REDEPLOY_SCRIPT_PATH"
+cancel_remote_run() {
+  "${SSH_COMMAND[@]}" "$REMOTE_TARGET" bash -s -- \
+    "$REMOTE_STATUS" "$REMOTE_PID" <<'REMOTE_CANCEL' || true
+set -euo pipefail
+status_path="$1"
+pid_path="$2"
 
-echo "[remote-redeploy] starting detached run $RUN_TOKEN"
-"${SSH_COMMAND[@]}" "$REMOTE_TARGET" bash -s -- \
-  "$REMOTE_REPOSITORY" \
-  "$RUN_TOKEN" \
-  "$TARGET_BACKEND_SHA" \
-  "$TARGET_BACKEND_DIGEST" <<'REMOTE_LAUNCHER'
+if [ -f "$status_path" ] || [ ! -f "$pid_path" ]; then
+  exit 0
+fi
+
+remote_pid="$(cat "$pid_path")"
+if [[ "$remote_pid" =~ ^[1-9][0-9]*$ ]]; then
+  kill -TERM -- "-${remote_pid}" 2>/dev/null || kill -TERM "$remote_pid" 2>/dev/null || true
+fi
+REMOTE_CANCEL
+}
+
+cleanup_initialization() {
+  local exit_code="$?"
+  trap - EXIT
+  if [ "$exit_code" -ne 0 ]; then
+    echo "[remote-redeploy] initialization failed; terminating a possible detached run" >&2
+    cancel_remote_run
+  fi
+  exit "$exit_code"
+}
+
+trap cleanup_initialization EXIT
+
+upload_remote_script() {
+  "${SSH_COMMAND[@]}" "$REMOTE_TARGET" \
+    "umask 077; install -d -m 700 '$REMOTE_RUN_DIRECTORY'; cat >'$REMOTE_SCRIPT'; chmod 700 '$REMOTE_SCRIPT'" \
+    <"$REDEPLOY_SCRIPT_PATH"
+}
+
+start_remote_run() {
+  "${SSH_COMMAND[@]}" "$REMOTE_TARGET" bash -s -- \
+    "$REMOTE_REPOSITORY" \
+    "$RUN_TOKEN" \
+    "$TARGET_BACKEND_SHA" \
+    "$TARGET_BACKEND_DIGEST" <<'REMOTE_LAUNCHER'
 set -Eeuo pipefail
 
 repository="$1"
@@ -120,14 +156,14 @@ if [ ! -x "$script_path" ]; then
   exit 2
 fi
 if [ -e "$status_path" ]; then
-  echo "[remote-redeploy] run token already completed; refusing to overwrite evidence" >&2
-  exit 1
+  echo "[remote-redeploy] run token already completed; resuming its monitor"
+  exit 0
 fi
 if [ -f "$pid_path" ]; then
   previous_pid="$(cat "$pid_path")"
   if [[ "$previous_pid" =~ ^[1-9][0-9]*$ ]] && kill -0 "$previous_pid" 2>/dev/null; then
-    echo "[remote-redeploy] run token is already active" >&2
-    exit 1
+    echo "[remote-redeploy] run token is already active; resuming its monitor"
+    exit 0
   fi
 fi
 
@@ -175,6 +211,36 @@ nohup setsid bash -c '
 
 printf '%s\n' "$!" >"$pid_path"
 REMOTE_LAUNCHER
+}
+
+retry_initial_transport() {
+  local operation="$1"
+  local attempt=1
+  local exit_code
+  shift
+
+  while true; do
+    if "$@"; then
+      return 0
+    else
+      exit_code="$?"
+    fi
+
+    if [ "$exit_code" -ne 255 ] || [ "$attempt" -ge "$INITIAL_TRANSPORT_ATTEMPTS" ]; then
+      return "$exit_code"
+    fi
+
+    echo "[remote-redeploy] ${operation} transport failure ${attempt}/${INITIAL_TRANSPORT_ATTEMPTS}; retrying" >&2
+    attempt=$((attempt + 1))
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+}
+
+echo "[remote-redeploy] uploading the validated redeploy script"
+retry_initial_transport upload upload_remote_script
+
+echo "[remote-redeploy] starting detached run $RUN_TOKEN"
+retry_initial_transport launch start_remote_run
 
 REMOTE_FINISHED=false
 NEXT_LOG_LINE=1
@@ -197,24 +263,6 @@ fetch_remote_log() {
   NEXT_LOG_LINE=$((NEXT_LOG_LINE + line_count))
   rm -f "$CURRENT_TEMP_FILE"
   CURRENT_TEMP_FILE=""
-}
-
-cancel_remote_run() {
-  "${SSH_COMMAND[@]}" "$REMOTE_TARGET" bash -s -- \
-    "$REMOTE_STATUS" "$REMOTE_PID" <<'REMOTE_CANCEL' || true
-set -euo pipefail
-status_path="$1"
-pid_path="$2"
-
-if [ -f "$status_path" ] || [ ! -f "$pid_path" ]; then
-  exit 0
-fi
-
-remote_pid="$(cat "$pid_path")"
-if [[ "$remote_pid" =~ ^[1-9][0-9]*$ ]]; then
-  kill -TERM -- "-${remote_pid}" 2>/dev/null || kill -TERM "$remote_pid" 2>/dev/null || true
-fi
-REMOTE_CANCEL
 }
 
 finish_local() {

--- a/tests/deploy/run-redeploy-remote-test.sh
+++ b/tests/deploy/run-redeploy-remote-test.sh
@@ -34,8 +34,34 @@ while [ "$#" -gt 0 ]; do
 done
 
 if [ "$#" -eq 1 ]; then
+  if [[ "$1" == *"install -d"* ]] && [ -n "${FAKE_SSH_UPLOAD_FAILURES:-}" ]; then
+    upload_attempt=0
+    if [ -f "${FAKE_SSH_UPLOAD_COUNTER_FILE}" ]; then
+      upload_attempt="$(cat "${FAKE_SSH_UPLOAD_COUNTER_FILE}")"
+    fi
+    if [ "$upload_attempt" -lt "$FAKE_SSH_UPLOAD_FAILURES" ]; then
+      printf '%s\n' "$((upload_attempt + 1))" >"${FAKE_SSH_UPLOAD_COUNTER_FILE}"
+      echo "simulated upload disconnect" >&2
+      exit 255
+    fi
+  fi
   exec bash -c "$1"
 fi
+
+if [ "$#" -eq 7 ] && [ "$1" = bash ] && [ "$2" = -s ] &&
+  [ -n "${FAKE_SSH_BREAK_LAUNCH_FILE:-}" ] && [ ! -f "$FAKE_SSH_BREAK_LAUNCH_FILE" ]; then
+  set +e
+  "$@"
+  launch_code="$?"
+  set -e
+  : >"$FAKE_SSH_BREAK_LAUNCH_FILE"
+  if [ "$launch_code" -ne 0 ]; then
+    exit "$launch_code"
+  fi
+  echo "simulated post-launch disconnect" >&2
+  exit 255
+fi
+
 exec "$@"
 FAKE_SSH
 
@@ -76,13 +102,21 @@ BACKEND_DIGEST="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 SUCCESS_OUTPUT="$TEMP_ROOT/success-output.log"
 PATH="$FAKE_BIN:$PATH" \
   SSH_BIN="$FAKE_BIN/ssh" \
+  FAKE_SSH_UPLOAD_FAILURES=2 \
+  FAKE_SSH_UPLOAD_COUNTER_FILE="$TEMP_ROOT/upload-attempts" \
+  FAKE_SSH_BREAK_LAUNCH_FILE="$TEMP_ROOT/launch-disconnect" \
   REDEPLOY_SCRIPT_PATH="$SUCCESS_FIXTURE" \
+  REDEPLOY_INITIAL_TRANSPORT_ATTEMPTS=5 \
   REDEPLOY_POLL_INTERVAL_SECONDS=1 \
   REDEPLOY_TIMEOUT_SECONDS=15 \
   bash "$RUNNER" \
   "$SSH_KEY" deploy@example.test "$REMOTE_REPOSITORY" \
-  "$BACKEND_SHA" "$BACKEND_DIGEST" success-run >"$SUCCESS_OUTPUT"
+  "$BACKEND_SHA" "$BACKEND_DIGEST" success-run >"$SUCCESS_OUTPUT" 2>&1
 
+grep -Fq 'upload transport failure 1/5; retrying' "$SUCCESS_OUTPUT"
+grep -Fq 'upload transport failure 2/5; retrying' "$SUCCESS_OUTPUT"
+grep -Fq 'launch transport failure 1/5; retrying' "$SUCCESS_OUTPUT"
+grep -Fq 'resuming its monitor' "$SUCCESS_OUTPUT"
 grep -Fq 'fixture started' "$SUCCESS_OUTPUT"
 grep -Fq 'fixture completed' "$SUCCESS_OUTPUT"
 grep -Fq 'detached run completed successfully' "$SUCCESS_OUTPUT"


### PR DESCRIPTION
## Problema

Después de desacoplar el proceso largo, DEV cortó la conexión durante la carga inicial del script (`Broken pipe`, exit 255), antes de crear el worker remoto.

## Solución

- Reintentar únicamente errores de transporte 255 durante carga y lanzamiento.
- Hacer el lanzamiento idempotente por token: si el proceso ya arrancó o terminó, continuar su monitor sin duplicarlo.
- Intentar cancelar cualquier worker posiblemente iniciado si la inicialización finalmente falla.

## Validación

La prueba simula dos cortes de carga y un corte posterior al lanzamiento, además de los casos normales de éxito y fallo remoto.

- `bash tests/deploy/run-redeploy-remote-test.sh`
- `bash tests/deploy/redeploy-environment-policy.sh`
- `actionlint .github/workflows/redeploy-non-production.yml`
- `git diff --check`

Run observado: https://github.com/sihsalus/sihsalus/actions/runs/30984979723

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->