### PR TITLE
chore(backend): use SIHSALUS content 1.24.0

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -62,7 +62,7 @@
     <fua.version>1.0.86</fua.version>
     <imaging.version>1.2.8</imaging.version>
     <!-- Content Packages -->
-    <sihsalus-content.version>1.23.9</sihsalus-content.version>
+    <sihsalus-content.version>1.24.0</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
   </properties>
 


### PR DESCRIPTION
Bump del paquete de contenido 1.23.9 → 1.24.0 (ya publicado y verificado en Maven Central).

1.24.0 aprovisiona el visit attribute type **Acompañante de consulta** (`710da0b9-e15f-47f0-827a-e97f1937c81d`) que el formulario de inicio de consulta necesita para persistir acompañantes (sihsalus-content#183). En DEV existe hoy por un insert manual vía REST; Iniz lo empatará por UUID sin duplicar. En QLTY lo creará por primera vez.

Tras el merge: Build Backend produce la imagen nueva y se ejecutará **Redeploy Non-Production** con su SHA/digest para el redeploy limpio de DEV y QLTY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->