### PR TITLE
fix(deploy): survive frontend SSH disconnects

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -129,7 +129,7 @@ jobs:
     name: Deploy DEV
     needs: resolve
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     environment:
       name: development
       url: https://gidis-hsc-dev.inf.pucp.edu.pe/openmrs/spa
@@ -148,29 +148,53 @@ jobs:
           chmod 600 "${HOME}/.ssh/deploy_key" "${HOME}/.ssh/known_hosts"
           ssh-keygen -y -f "${HOME}/.ssh/deploy_key" >/dev/null
 
-      - name: Validate deployment script
-        run: bash -n scripts/deploy/deploy-frontend.sh
+      - name: Validate deployment scripts
+        run: |
+          bash -n scripts/deploy/deploy-frontend.sh
+          bash -n scripts/deploy/run-redeploy-remote.sh
 
       - name: Deploy verified frontend
         env:
           TARGET_SHA: ${{ needs.resolve.outputs.sha }}
           TARGET_DIGEST: ${{ needs.resolve.outputs.digest }}
         run: |
-          ssh \
-            -i "${HOME}/.ssh/deploy_key" \
-            -o BatchMode=yes \
-            -o IdentitiesOnly=yes \
-            -o StrictHostKeyChecking=yes \
-            -o ConnectTimeout=15 \
+          set -euo pipefail
+          REDEPLOY_SCRIPT_PATH=scripts/deploy/deploy-frontend.sh \
+            REDEPLOY_TIMEOUT_SECONDS=1200 \
+            scripts/deploy/run-redeploy-remote.sh \
+            "${HOME}/.ssh/deploy_key" \
             u.hsc.dev@200.16.7.137 \
-            "cd /home/u.hsc.dev/sihsalus && bash -s -- '${TARGET_SHA}' '${TARGET_DIGEST}'" \
-            <scripts/deploy/deploy-frontend.sh
+            /home/u.hsc.dev/sihsalus \
+            "${TARGET_SHA}" \
+            "${TARGET_DIGEST}" \
+            "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-frontend-dev"
+
+      - name: Verify DEV externally
+        env:
+          TARGET_SHA: ${{ needs.resolve.outputs.sha }}
+        run: |
+          set -euo pipefail
+          base='https://gidis-hsc-dev.inf.pucp.edu.pe'
+          curl --insecure --fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 5 \
+            "${base}/health" >/dev/null
+          curl --insecure --fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 5 \
+            "${base}/ready" >/dev/null
+          actual_sha="$(
+            curl --insecure --fail --silent --show-error \
+              -H 'Cache-Control: no-cache' \
+              "${base}/openmrs/spa/build-info.json?release=${TARGET_SHA}" |
+              jq -r '.gitSha // empty'
+          )"
+          if [ "${actual_sha}" != "${TARGET_SHA}" ]; then
+            echo "::error::DEV serves frontend ${actual_sha:-unknown}, expected ${TARGET_SHA}."
+            exit 1
+          fi
 
   deploy-qlty:
     name: Deploy QLTY
     needs: [resolve, deploy-dev]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     environment:
       name: quality
       url: https://gidis-hsc-qlty.inf.pucp.edu.pe/openmrs/spa
@@ -189,20 +213,44 @@ jobs:
           chmod 600 "${HOME}/.ssh/deploy_key" "${HOME}/.ssh/known_hosts"
           ssh-keygen -y -f "${HOME}/.ssh/deploy_key" >/dev/null
 
-      - name: Validate deployment script
-        run: bash -n scripts/deploy/deploy-frontend.sh
+      - name: Validate deployment scripts
+        run: |
+          bash -n scripts/deploy/deploy-frontend.sh
+          bash -n scripts/deploy/run-redeploy-remote.sh
 
       - name: Deploy verified frontend
         env:
           TARGET_SHA: ${{ needs.resolve.outputs.sha }}
           TARGET_DIGEST: ${{ needs.resolve.outputs.digest }}
         run: |
-          ssh \
-            -i "${HOME}/.ssh/deploy_key" \
-            -o BatchMode=yes \
-            -o IdentitiesOnly=yes \
-            -o StrictHostKeyChecking=yes \
-            -o ConnectTimeout=15 \
+          set -euo pipefail
+          REDEPLOY_SCRIPT_PATH=scripts/deploy/deploy-frontend.sh \
+            REDEPLOY_TIMEOUT_SECONDS=1200 \
+            scripts/deploy/run-redeploy-remote.sh \
+            "${HOME}/.ssh/deploy_key" \
             u.hsc.qlty@200.16.7.138 \
-            "cd /home/u.hsc.qlty/sihsalus && bash -s -- '${TARGET_SHA}' '${TARGET_DIGEST}'" \
-            <scripts/deploy/deploy-frontend.sh
+            /home/u.hsc.qlty/sihsalus \
+            "${TARGET_SHA}" \
+            "${TARGET_DIGEST}" \
+            "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-frontend-qlty"
+
+      - name: Verify QLTY externally
+        env:
+          TARGET_SHA: ${{ needs.resolve.outputs.sha }}
+        run: |
+          set -euo pipefail
+          base='https://gidis-hsc-qlty.inf.pucp.edu.pe'
+          curl --insecure --fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 5 \
+            "${base}/health" >/dev/null
+          curl --insecure --fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 5 \
+            "${base}/ready" >/dev/null
+          actual_sha="$(
+            curl --insecure --fail --silent --show-error \
+              -H 'Cache-Control: no-cache' \
+              "${base}/openmrs/spa/build-info.json?release=${TARGET_SHA}" |
+              jq -r '.gitSha // empty'
+          )"
+          if [ "${actual_sha}" != "${TARGET_SHA}" ]; then
+            echo "::error::QLTY serves frontend ${actual_sha:-unknown}, expected ${TARGET_SHA}."
+            exit 1
+          fi

--- a/tests/frontend/deploy-frontend.sh
+++ b/tests/frontend/deploy-frontend.sh
@@ -3,8 +3,19 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/deploy-frontend.yml"
+REMOTE_RUNNER="$ROOT/scripts/deploy/run-redeploy-remote.sh"
 TEST_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TEST_ROOT"' EXIT
+
+bash -n "$REMOTE_RUNNER"
+[ "$(grep -Fc 'REDEPLOY_SCRIPT_PATH=scripts/deploy/deploy-frontend.sh' "$WORKFLOW")" -eq 2 ]
+grep -Fq 'Verify DEV externally' "$WORKFLOW"
+grep -Fq 'Verify QLTY externally' "$WORKFLOW"
+if grep -Fq '<scripts/deploy/deploy-frontend.sh' "$WORKFLOW"; then
+  echo "frontend workflow still streams a long deployment over one SSH session" >&2
+  exit 1
+fi
 
 OLD_SHA='1111111111111111111111111111111111111111'
 TARGET_SHA='2222222222222222222222222222222222222222'


### PR DESCRIPTION
## Summary
- run frontend deployment as a detached, locked remote task with resumable SSH polling
- keep SHA/digest pinning and frontend-only rollback semantics unchanged
- verify DEV and QLTY externally serve the requested frontend SHA
- add a policy regression check preventing a return to one long SSH stream

## Evidence
- `./tests/deploy/redeploy-environment-policy.sh`
- `./tests/frontend/deploy-frontend.sh`
- workflow YAML parsed locally

## Why
Recent frontend deployments failed with SSH exit 255 / `Broken pipe` while pulling the immutable image. The deployment can outlive transient transport failures and its final state is independently verified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->