### PR TITLE
test(deploy): cover successful one-shot services

### DIFF
--- a/tests/deploy/redeploy-environment-policy.sh
+++ b/tests/deploy/redeploy-environment-policy.sh
@@ -49,6 +49,15 @@ grep -Fq -- '-o ServerAliveInterval=15' "$REMOTE_RUNNER"
 grep -Fq -- '-o ServerAliveCountMax=3' "$REMOTE_RUNNER"
 grep -Fq 'flock -n 9' "$REMOTE_RUNNER"
 
+eval "$(sed -n '/^service_allows_successful_exit() {/,/^}/p' "$SCRIPT")"
+service_allows_successful_exit backend-oauth2-config
+service_allows_successful_exit certbot
+service_allows_successful_exit loki-init
+if service_allows_successful_exit frontend; then
+  echo "[FAIL] a long-running service may not exit successfully during redeploy" >&2
+  exit 1
+fi
+
 bash "$REMOTE_RUNNER_TEST"
 
 echo "[OK] full environment redeploy policy"


### PR DESCRIPTION
## Summary
- regression-test the successful-exit allowlist added in #234
- verify backend-oauth2-config, certbot, and loki-init are accepted
- verify a long-running service such as frontend is rejected

## Validation
- ./tests/deploy/redeploy-environment-policy.sh
- ./tests/frontend/deploy-frontend.sh
- bash -n scripts/deploy/redeploy-environment.sh tests/deploy/redeploy-environment-policy.sh
- git diff --check