### PR TITLE
chore(backend): use SIHSALUS content 1.24.1

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -62,7 +62,7 @@
     <fua.version>1.0.86</fua.version>
     <imaging.version>1.2.8</imaging.version>
     <!-- Content Packages -->
-    <sihsalus-content.version>1.24.0</sihsalus-content.version>
+    <sihsalus-content.version>1.24.1</sihsalus-content.version>
     <reference-content.version>1.4.0</reference-content.version>
   </properties>
 


### PR DESCRIPTION
Bump de contenido 1.24.0 → 1.24.1, ya publicado y verificado en Maven Central (`sihsalus-content-1.24.1.zip`, HTTP 200).

1.24.1 corrige el formulario `Prescripción de medicamentos` (sihsalus-content#186):
- la obs «Observaciones» dejaba de guardar en el concepto **Evolución obstétrica** y pasa a «Instrucciones de prescripción, no codificadas»;
- el lanzador de suplementos usaba `workspaceContext`, clave que el motor ignora, y pasa a `workspaceProps`, de modo que el set «Suplementos para gestantes» por fin filtra el order basket.

Incluye además el validador de integridad terminológica en el CI del contenido (sihsalus-content#185), que no afecta al artefacto desplegado.

Tras el merge: Build Backend produce la imagen y se ejecuta **Redeploy Non-Production** con su SHA y digest para DEV y QLTY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/sihsalus/pr/236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->